### PR TITLE
MOBILE-1168: Resolve possible navigation bar issues

### DIFF
--- a/Sources/Kevin/Accounts/BankSelection/KevinBankSelectionViewController.swift
+++ b/Sources/Kevin/Accounts/BankSelection/KevinBankSelectionViewController.swift
@@ -32,11 +32,6 @@ internal class KevinBankSelectionViewController :
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         uiStateHandler.setNavigationController(navigationController: navigationController)
-        uiStateHandler.setNavigationBarColor(
-            UIApplication.shared.isLightThemedInterface ?
-            Kevin.shared.theme.navigationBarStyle.backgroundColorLightMode :
-                Kevin.shared.theme.navigationBarStyle.backgroundColorDarkMode
-        )
         uiStateHandler.forceStopCancellation = false
     }
 
@@ -44,7 +39,6 @@ internal class KevinBankSelectionViewController :
         super.viewDidDisappear(animated)
         if uiStateHandler.isCancellationInvoked {
             self.onExit?()
-            uiStateHandler.resetState()
         }
     }
     

--- a/Sources/Kevin/Core/Custom/KevinNavigationViewController.swift
+++ b/Sources/Kevin/Core/Custom/KevinNavigationViewController.swift
@@ -14,8 +14,6 @@ internal class KevinNavigationViewController: UINavigationController {
         super.viewDidLoad()
         
         delegate = self
-        navigationBar.shadowImage = UIImage()
-        navigationBar.isTranslucent = false
         
         interactivePopGestureRecognizer?.delegate = self
         interactivePopGestureRecognizer?.isEnabled = true
@@ -23,29 +21,11 @@ internal class KevinNavigationViewController: UINavigationController {
     
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
-        configureNavigationBar()
+        applyKevinNavigationBarStyle()
     }
     
     override var preferredStatusBarStyle: UIStatusBarStyle {
         return .lightContent
-    }
-    
-    private func configureNavigationBar() {
-        if #available(iOS 13.0, *) {
-            let appearance = UINavigationBarAppearance()
-            appearance.configureWithOpaqueBackground()
-            appearance.backgroundColor = UIApplication.shared.isLightThemedInterface ?
-            Kevin.shared.theme.navigationBarStyle.backgroundColorLightMode :
-            Kevin.shared.theme.navigationBarStyle.backgroundColorDarkMode
-            appearance.titleTextAttributes = [NSAttributedString.Key.foregroundColor: Kevin.shared.theme.navigationBarStyle.titleColor]
-            navigationBar.standardAppearance = appearance
-            navigationBar.scrollEdgeAppearance = navigationBar.standardAppearance
-        } else {
-            navigationBar.barTintColor = UIApplication.shared.isLightThemedInterface ?
-            Kevin.shared.theme.navigationBarStyle.backgroundColorLightMode :
-            Kevin.shared.theme.navigationBarStyle.backgroundColorDarkMode
-            navigationBar.titleTextAttributes = [NSAttributedString.Key.foregroundColor: Kevin.shared.theme.navigationBarStyle.titleColor]
-        }
     }
 }
 

--- a/Sources/Kevin/Core/Custom/KevinUIStateHandler.swift
+++ b/Sources/Kevin/Core/Custom/KevinUIStateHandler.swift
@@ -17,38 +17,12 @@ internal class KevinUIStateHandler {
             (navigationController?.isMovingFromParent ?? false || !forceStopCancellation) &&
             !(navigationController?.viewControllers.last is KevinPaymentConfirmationViewController ||
               navigationController?.viewControllers.last is KevinAccountLinkingViewController)
-            
         }
     }
 
-    private var previousNavigationBarBackgroundColor: UIColor?
-    private var previousStatusBarBackgroundColor: UIColor?
-    
     private var navigationController: UINavigationController?
     
     func setNavigationController(navigationController: UINavigationController?) {
         self.navigationController = navigationController
-    }
-    
-    func setNavigationBarColor(_ color: UIColor) {
-        previousNavigationBarBackgroundColor = navigationController?.navigationBar.backgroundColor
-        previousStatusBarBackgroundColor = UIApplication.shared.statusBarUIView?.backgroundColor
-        setNavigationBarColor(navigationBarColor: color, statusBarColor: color)
-    }
-    
-    func resetState() {
-        setNavigationBarColor(
-            navigationBarColor: previousNavigationBarBackgroundColor,
-            statusBarColor: previousStatusBarBackgroundColor
-        )
-    }
-    
-    private func setNavigationBarColor(navigationBarColor: UIColor?, statusBarColor: UIColor?) {
-        if !(navigationController is KevinNavigationViewController) {
-            navigationController?.navigationBar.backgroundColor = navigationBarColor
-            if #available(iOS 13.0, *) {
-                UIApplication.shared.statusBarUIView?.backgroundColor = statusBarColor
-            }
-        }
     }
 }

--- a/Sources/Kevin/Core/Extensions/UIApplication+StatusBar.swift
+++ b/Sources/Kevin/Core/Extensions/UIApplication+StatusBar.swift
@@ -9,27 +9,6 @@
 import UIKit
 
 extension UIApplication {
-    var statusBarUIView: UIView? {
-        if #available(iOS 13.0, *) {
-            let tag = 38482
-            let keyWindow = UIApplication.shared.windows.filter { $0.isKeyWindow }.first
-            
-            if let statusBar = keyWindow?.viewWithTag(tag) {
-                return statusBar
-            } else {
-                guard let statusBarFrame = keyWindow?.windowScene?.statusBarManager?.statusBarFrame else { return nil }
-                let statusBarView = UIView(frame: statusBarFrame)
-                statusBarView.tag = tag
-                keyWindow?.addSubview(statusBarView)
-                return statusBarView
-            }
-        } else if responds(to: Selector(("statusBar"))) {
-            return value(forKey: "statusBar") as? UIView
-        } else {
-            return nil
-        }
-    }
-    
     var isLightThemedInterface: Bool {
         if #available(iOS 13.0, *) {
             let interfaceStyle = UIApplication.shared.keyWindow?.overrideUserInterfaceStyle == .unspecified ?

--- a/Sources/Kevin/Core/Extensions/UINavigationController+Extensions.swift
+++ b/Sources/Kevin/Core/Extensions/UINavigationController+Extensions.swift
@@ -1,0 +1,30 @@
+import UIKit
+
+public extension UINavigationController {
+    
+    func applyKevinNavigationBarStyle() {
+        if #available(iOS 13.0, *) {
+            let appearance = UINavigationBarAppearance()
+            appearance.configureWithOpaqueBackground()
+            appearance.backgroundColor = .init { traitCollection in
+                UIApplication.shared.isLightThemedInterface ?
+                Kevin.shared.theme.navigationBarStyle.backgroundColorLightMode :
+                Kevin.shared.theme.navigationBarStyle.backgroundColorDarkMode
+            }
+            appearance.titleTextAttributes = [NSAttributedString.Key.foregroundColor: Kevin.shared.theme.navigationBarStyle.titleColor]
+            appearance.largeTitleTextAttributes = [NSAttributedString.Key.foregroundColor: Kevin.shared.theme.navigationBarStyle.titleColor]
+            appearance.shadowImage = UIImage()
+            appearance.shadowColor = .clear
+            navigationBar.standardAppearance = appearance
+            navigationBar.compactAppearance = appearance
+            navigationBar.scrollEdgeAppearance = navigationBar.standardAppearance
+        } else {
+            navigationBar.barTintColor = UIApplication.shared.isLightThemedInterface ?
+            Kevin.shared.theme.navigationBarStyle.backgroundColorLightMode :
+            Kevin.shared.theme.navigationBarStyle.backgroundColorDarkMode
+            navigationBar.shadowImage = UIImage()
+            navigationBar.isTranslucent = false
+            navigationBar.titleTextAttributes = [NSAttributedString.Key.foregroundColor: Kevin.shared.theme.navigationBarStyle.titleColor]
+        }
+    }
+}

--- a/Sources/Kevin/InAppPayments/CardPayment/KevinCardPaymentViewController.swift
+++ b/Sources/Kevin/InAppPayments/CardPayment/KevinCardPaymentViewController.swift
@@ -32,11 +32,6 @@ internal class KevinCardPaymentViewController :
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         uiStateHandler.setNavigationController(navigationController: navigationController)
-        uiStateHandler.setNavigationBarColor(
-            UIApplication.shared.isLightThemedInterface ?
-            Kevin.shared.theme.navigationBarStyle.backgroundColorLightMode :
-                Kevin.shared.theme.navigationBarStyle.backgroundColorDarkMode
-        )
         uiStateHandler.forceStopCancellation = false
     }
 
@@ -44,7 +39,6 @@ internal class KevinCardPaymentViewController :
         super.viewDidDisappear(animated)
         if uiStateHandler.isCancellationInvoked {
             self.onExit?()
-            uiStateHandler.resetState()
         }
     }
     

--- a/Sources/Kevin/InAppPayments/PaymentConfirmation/KevinPaymentConfirmationViewController.swift
+++ b/Sources/Kevin/InAppPayments/PaymentConfirmation/KevinPaymentConfirmationViewController.swift
@@ -36,11 +36,6 @@ internal class KevinPaymentConfirmationViewController :
         super.viewWillAppear(animated)
         if configuration.skipAuthentication || configuration.paymentType == .card {
             uiStateHandler?.setNavigationController(navigationController: navigationController)
-            uiStateHandler?.setNavigationBarColor(
-                UIApplication.shared.isLightThemedInterface ?
-                Kevin.shared.theme.navigationBarStyle.backgroundColorLightMode :
-                    Kevin.shared.theme.navigationBarStyle.backgroundColorDarkMode
-            )
         }
     }
     
@@ -55,7 +50,6 @@ internal class KevinPaymentConfirmationViewController :
                         error: KevinCancelationError(description: "Payment was canceled!")
                     )
                 )
-                uiStateHandler?.resetState()
             }
         }
     }


### PR DESCRIPTION
There is an issue with navigation bars on Whitelabel App. 
This happens because we are configuring the Navigation bar inside of the framework and instead using our own Navigation Controller. 
- The previous approach tried to account for that factory saving in special class previous colours and in ViewController itself re applying the style. 
- In solution, if you extracted the view controller from UINavigationController you will have to apply the style yourself manually or you can use your own style. Hence `applyKevinNavigationBarStyle`

There will second PR for Whitelabel app to apply this style 