### PR TITLE
MOBILE-1280: Add Cocoapods support

### DIFF
--- a/Sources/Kevin/Accounts/BankSelection/KevinBankSelectionView.swift
+++ b/Sources/Kevin/Accounts/BankSelection/KevinBankSelectionView.swift
@@ -27,7 +27,7 @@ internal class KevinBankSelectionView : KevinView<KevinBankSelectionState> {
     private var selectedBankId: String!
     
     public override func render(state: KevinBankSelectionState) {
-        countrySelectionIconView.image = UIImage(named: "flag\(state.selectedCountry.uppercased())", in: Bundle.module, compatibleWith: nil)
+        countrySelectionIconView.image = UIImage(named: "flag\(state.selectedCountry.uppercased())", in: Bundle.current, compatibleWith: nil)
         let countryName = "country_name_\(state.selectedCountry)".localized(for: Kevin.shared.locale.identifier)
         countrySelectionCountryLabel.text = countryName
         bankItems = state.bankItems

--- a/Sources/Kevin/Accounts/BankSelection/KevinEmptyStateView.swift
+++ b/Sources/Kevin/Accounts/BankSelection/KevinEmptyStateView.swift
@@ -11,7 +11,7 @@ final internal class KevinEmptyStateView: UIView {
     }()
     
     private let iconImageView: UIImageView = {
-        let imageView = UIImageView(image: UIImage(named: "error", in: .module, compatibleWith: nil)?.withRenderingMode(.alwaysTemplate))
+        let imageView = UIImageView(image: UIImage(named: "error", in: .current, compatibleWith: nil)?.withRenderingMode(.alwaysTemplate))
         imageView.tintColor = Kevin.shared.theme.emptyStateStyle.iconTintColor
         imageView.translatesAutoresizingMaskIntoConstraints = false
         return imageView

--- a/Sources/Kevin/Accounts/CountrySelection/KevinCountrySelectionView.swift
+++ b/Sources/Kevin/Accounts/CountrySelection/KevinCountrySelectionView.swift
@@ -100,7 +100,7 @@ extension KevinCountrySelectionView: UITableViewDataSource {
         }
         
         cell!.backgroundOverlay.isHidden = !(countryItems[indexPath.row].uppercased() == selectedCountry.uppercased())
-        cell!.iconImageView.image = UIImage(named: "flag\(countryItems[indexPath.row].uppercased())", in: Bundle.module, compatibleWith: nil)
+        cell!.iconImageView.image = UIImage(named: "flag\(countryItems[indexPath.row].uppercased())", in: Bundle.current, compatibleWith: nil)
         cell!.titleLabel.text = "country_name_\(countryItems[indexPath.row].lowercased())".localized(for: Kevin.shared.locale.identifier)
         
         return cell!

--- a/Sources/Kevin/Core/Extensions/Bundle+Extensions.swift
+++ b/Sources/Kevin/Core/Extensions/Bundle+Extensions.swift
@@ -1,0 +1,33 @@
+//
+//  Kevin.swift
+//  kevin.iOS
+//
+//  Created by Edgar Žigis on 8/1/21.
+//  Copyright © 2022 kevin.. All rights reserved.
+//
+
+import class Foundation.Bundle
+private class BundleFinder {}
+extension Foundation.Bundle {
+        /// Returns the resource bundle associated with the current Swift module.
+        static var current: Bundle = {
+                // This is your `target.path` (located in your `Package.swift`) by replacing all the `/` by the `_`.
+                let bundleName = "Kevin"
+                let candidates = [
+                        // Bundle should be present here when the package is linked into an App.
+                        Bundle.main.resourceURL,
+                        // Bundle should be present here when the package is linked into a framework.
+                        Bundle(for: BundleFinder.self).resourceURL,
+                        // For command-line tools.
+                        Bundle.main.bundleURL,
+                ]
+                for candidate in candidates {
+                        let bundlePath = candidate?.appendingPathComponent(bundleName + ".bundle")
+                        if let bundle = bundlePath.flatMap(Bundle.init(url:)) {
+                                return bundle
+                        }
+                }
+                
+                return Bundle(for: BundleFinder.self)
+        }()
+}

--- a/Sources/Kevin/Core/Extensions/Bundle+Extensions.swift
+++ b/Sources/Kevin/Core/Extensions/Bundle+Extensions.swift
@@ -2,32 +2,27 @@
 //  Kevin.swift
 //  kevin.iOS
 //
-//  Created by Edgar Žigis on 8/1/21.
 //  Copyright © 2022 kevin.. All rights reserved.
 //
 
 import class Foundation.Bundle
 private class BundleFinder {}
 extension Foundation.Bundle {
-        /// Returns the resource bundle associated with the current Swift module.
-        static var current: Bundle = {
-                // This is your `target.path` (located in your `Package.swift`) by replacing all the `/` by the `_`.
-                let bundleName = "Kevin"
-                let candidates = [
-                        // Bundle should be present here when the package is linked into an App.
-                        Bundle.main.resourceURL,
-                        // Bundle should be present here when the package is linked into a framework.
-                        Bundle(for: BundleFinder.self).resourceURL,
-                        // For command-line tools.
-                        Bundle.main.bundleURL,
-                ]
-                for candidate in candidates {
-                        let bundlePath = candidate?.appendingPathComponent(bundleName + ".bundle")
-                        if let bundle = bundlePath.flatMap(Bundle.init(url:)) {
-                                return bundle
-                        }
-                }
-                
-                return Bundle(for: BundleFinder.self)
-        }()
+    /// Returns the resource bundle associated with the current Swift module.
+    static var current: Bundle = {
+        let bundleName = "Kevin_Kevin"
+        let candidates = [
+            Bundle.main.resourceURL,
+            Bundle(for: BundleFinder.self).resourceURL,
+            Bundle.main.bundleURL,
+        ]
+        for candidate in candidates {
+            let bundlePath = candidate?.appendingPathComponent(bundleName + ".bundle")
+            if let bundle = bundlePath.flatMap(Bundle.init(url:)) {
+                return bundle
+            }
+        }
+        
+        return Bundle(for: BundleFinder.self)
+    }()
 }

--- a/Sources/Kevin/Core/Extensions/String+Localization.swift
+++ b/Sources/Kevin/Core/Extensions/String+Localization.swift
@@ -11,7 +11,7 @@ import Foundation
 extension String {
     
     func localized(for lang: String) -> String {
-        if let path = Bundle.module.path(forResource: lang, ofType: "lproj") {
+        if let path = Bundle.current.path(forResource: lang, ofType: "lproj") {
             return NSLocalizedString(self, tableName: nil, bundle: Bundle(path: path)!, value: "", comment: "")
         }
         return self

--- a/Sources/Kevin/Core/Styles/KevinTheme.swift
+++ b/Sources/Kevin/Core/Styles/KevinTheme.swift
@@ -36,8 +36,8 @@ open class KevinTheme {
         public var tintColor = UIColor.white
         public var backgroundColorLightMode = UIColor(red: 1, green: 0, blue: 32/255, alpha: 1)
         public var backgroundColorDarkMode = UIColor(red: 1, green: 0, blue: 32/255, alpha: 1)
-        public var backButtonImage = UIImage(named: "backButtonIcon", in: Bundle.module, compatibleWith: nil)
-        public var closeButtonImage = UIImage(named: "closeButtonIcon", in: Bundle.module, compatibleWith: nil)
+        public var backButtonImage = UIImage(named: "backButtonIcon", in: Bundle.current, compatibleWith: nil)
+        public var closeButtonImage = UIImage(named: "closeButtonIcon", in: Bundle.current, compatibleWith: nil)
         
         public init() { }
     }
@@ -71,7 +71,7 @@ open class KevinTheme {
         public var cellBackgroundColor = UIColor.white
         public var cellSelectedBackgroundColor = UIColor(red: 226/255, green: 225/255, blue: 234/255, alpha: 1)
         public var titleLabelFont = UIFont.systemFont(ofSize: 15, weight: .semibold)
-        public var chevronImage: UIImage? = UIImage(named: "chevronIcon", in: Bundle.module, compatibleWith: nil)
+        public var chevronImage: UIImage? = UIImage(named: "chevronIcon", in: Bundle.current, compatibleWith: nil)
         
         public init() { }
     }
@@ -83,7 +83,7 @@ open class KevinTheme {
         public var cornerRadius: CGFloat = 10
         public var borderWidth: CGFloat = 0
         public var borderColor = UIColor(red: 226/255, green: 225/255, blue: 234/255, alpha: 1)
-        public var chevronImage: UIImage? = UIImage(named: "chevronIcon", in: Bundle.module, compatibleWith: nil)
+        public var chevronImage: UIImage? = UIImage(named: "chevronIcon", in: Bundle.current, compatibleWith: nil)
         
         public init() { }
     }

--- a/Sources/Kevin/InAppPayments/CardPayment/KevinCardPaymentView.swift
+++ b/Sources/Kevin/InAppPayments/CardPayment/KevinCardPaymentView.swift
@@ -127,7 +127,7 @@ internal class KevinCardPaymentView: KevinView<KevinCardPaymentState> {
     
     private func initAmountContainer() {
         cardFormContainerView.addSubview(cardIconView)
-        cardIconView.image = UIImage(named: "card", in: Bundle.module, compatibleWith: nil)
+        cardIconView.image = UIImage(named: "card", in: Bundle.current, compatibleWith: nil)
         cardIconView.translatesAutoresizingMaskIntoConstraints = false
         cardIconView.centerXAnchor.constraint(equalTo: cardFormContainerView.centerXAnchor).isActive = true
         cardIconView.topAnchor.constraint(equalTo: cardFormContainerView.topAnchor, constant: 24).isActive = true
@@ -280,7 +280,7 @@ internal class KevinCardPaymentView: KevinView<KevinCardPaymentState> {
         cvvLabel.setContentHuggingPriority(.defaultHigh, for: .horizontal)
 
         cvvContainer.addSubview(cvvLabelHint)
-        cvvLabelHint.image = UIImage(named: "questionMark", in: Bundle.module, compatibleWith: nil)
+        cvvLabelHint.image = UIImage(named: "questionMark", in: Bundle.current, compatibleWith: nil)
         cvvLabelHint.translatesAutoresizingMaskIntoConstraints = false
         cvvLabelHint.leftAnchor.constraint(equalTo: cvvLabel.rightAnchor, constant: 4).isActive = true
         cvvLabelHint.rightAnchor.constraint(lessThanOrEqualTo: cvvContainer.rightAnchor).isActive = true
@@ -326,7 +326,7 @@ internal class KevinCardPaymentView: KevinView<KevinCardPaymentState> {
     
     private func initPaymentNoticeLabel() {
         cardFormContainerView.addSubview(paymentNoticeIcon)
-        paymentNoticeIcon.image = UIImage(named: "warning", in: Bundle.module, compatibleWith: nil)
+        paymentNoticeIcon.image = UIImage(named: "warning", in: Bundle.current, compatibleWith: nil)
         paymentNoticeIcon.translatesAutoresizingMaskIntoConstraints = false
         paymentNoticeIcon.leftAnchor.constraint(equalTo: cardFormContainerView.leftAnchor, constant: 18).isActive = true
         paymentNoticeIcon.widthAnchor.constraint(equalToConstant: 20).isActive = true

--- a/Sources/Kevin/InAppPayments/CardPayment/Views/KevinBankTransferPromptView.swift
+++ b/Sources/Kevin/InAppPayments/CardPayment/Views/KevinBankTransferPromptView.swift
@@ -65,7 +65,7 @@ internal class KevinBankTransferPromptView: UIView {
         containerViewTopConstraint?.isActive = true
 
         containerView.addSubview(bankIcon)
-        bankIcon.image = UIImage(named: "bank", in: Bundle.module, compatibleWith: nil)
+        bankIcon.image = UIImage(named: "bank", in: Bundle.current, compatibleWith: nil)
         bankIcon.translatesAutoresizingMaskIntoConstraints = false
         bankIcon.centerXAnchor.constraint(equalTo: containerView.centerXAnchor).isActive = true
         bankIcon.topAnchor.constraint(equalTo: containerView.topAnchor, constant: 50).isActive = true

--- a/kevin-ios.podspec
+++ b/kevin-ios.podspec
@@ -1,0 +1,21 @@
+Pod::Spec.new do |spec|
+  spec.name         = "kevin-ios"
+  spec.version      = "2.2.1"
+  spec.summary      = "Simplified kevin. integration for the iOS clients."
+
+  spec.homepage     = "https://github.com/getkevin/kevin-ios"
+  spec.screenshots  = "https://github.com/getkevin/kevin-ios/raw/master/images/logo.png"
+
+
+  spec.license      = { :type => 'MIT', :file => './LICENSE' }
+
+  spec.author       = "kevin."
+
+  spec.platform     = :ios
+  spec.ios.deployment_target = '9.0'
+  spec.swift_version = '5.0'
+  
+  spec.source       = { :git => "https://github.com/getkevin/kevin-ios.git", :tag => "#{spec.version}" }
+
+  spec.source_files  = "Sources/Kevin/**/*.{swift}"
+end

--- a/kevin-ios.podspec
+++ b/kevin-ios.podspec
@@ -18,4 +18,10 @@ Pod::Spec.new do |spec|
   spec.source       = { :git => "https://github.com/getkevin/kevin-ios.git", :tag => "#{spec.version}" }
 
   spec.source_files  = "Sources/Kevin/**/*.{swift}"
+  spec.resource_bundles = {
+    'Kevin_Kevin' => [ 
+       'Sources/Kevin/Resources/*.lproj',
+       'Sources/Kevin/Resources/Assets.xcassets'
+    ]
+  }
 end


### PR DESCRIPTION
There was an issue that during validation `pod lib lint` xcodebuild could not find Bundle.module since Cocoapods is a dynamically linked library. 
- The extension seems to be working fine with our demo app for the Local SPM package. 
- Tested also running Test app Kevin framework with Cocoapods 
`pod 'kevin-ios', :git => 'https://github.com/getkevin/kevin-ios.git', :branch => 'MOBILE-1280-CocoaPods'`

**N.B**

We still would need push pod to spec 

`pod repo push SPEC_REPO *.podspec --verbose`