### PR TITLE
MOBILE-1655 Get supported banks request fails if country is not provided

### DIFF
--- a/Sources/Kevin/Core/Networking/Utils/NSMutableURLRequestEncoder.swift
+++ b/Sources/Kevin/Core/Networking/Utils/NSMutableURLRequestEncoder.swift
@@ -70,6 +70,8 @@ class NSMutableURLRequestEncoder {
             for value in Array(set) {
                 components += queryComponents(fromKey: "\(key)", value: value)
             }
+        case Optional<Any>.none:
+            break
         default:
             let unwrappedValue = unwrap(value)
             components.append((key, escape("\(unwrappedValue)")))


### PR DESCRIPTION
If URL query parameter is `nil` that parameter should be omitted. 