### PR TITLE
MOBILE-1664: KevinAccountLinkingViewController when dismissed does not notify delegate about cancellation

### DIFF
--- a/Sources/Kevin/Accounts/AccountLinking/KevinAccountLinkingViewController.swift
+++ b/Sources/Kevin/Accounts/AccountLinking/KevinAccountLinkingViewController.swift
@@ -13,6 +13,7 @@ internal class KevinAccountLinkingViewController :
     KevinViewController<KevinAccountLinkingViewModel, KevinAccountLinkingView, KevinAccountLinkingState, KevinAccountLinkingIntent> {
     
     var configuration: KevinAccountLinkingConfiguration!
+    public var onExit: (() -> ())?
     
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -29,6 +30,10 @@ internal class KevinAccountLinkingViewController :
             name: .onHandleDeepLinkReceived,
             object: nil
         )
+    }
+    
+    override func onCloseTapped() {
+        dismiss(animated: true, completion: onExit)
     }
     
     override func viewDidDisappear(_ animated: Bool) {

--- a/Sources/Kevin/Accounts/AccountLinking/KevinAccountLinkingViewController.swift
+++ b/Sources/Kevin/Accounts/AccountLinking/KevinAccountLinkingViewController.swift
@@ -13,7 +13,7 @@ internal class KevinAccountLinkingViewController :
     KevinViewController<KevinAccountLinkingViewModel, KevinAccountLinkingView, KevinAccountLinkingState, KevinAccountLinkingIntent> {
     
     var configuration: KevinAccountLinkingConfiguration!
-    var onExit: (() -> ())?
+    var onClose: (() -> Void)?
     
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -33,7 +33,7 @@ internal class KevinAccountLinkingViewController :
     }
     
     override func onCloseTapped() {
-        dismiss(animated: true, completion: onExit)
+        dismiss(animated: true, completion: onClose)
     }
     
     override func viewDidDisappear(_ animated: Bool) {

--- a/Sources/Kevin/Accounts/AccountLinking/KevinAccountLinkingViewController.swift
+++ b/Sources/Kevin/Accounts/AccountLinking/KevinAccountLinkingViewController.swift
@@ -13,7 +13,7 @@ internal class KevinAccountLinkingViewController :
     KevinViewController<KevinAccountLinkingViewModel, KevinAccountLinkingView, KevinAccountLinkingState, KevinAccountLinkingIntent> {
     
     var configuration: KevinAccountLinkingConfiguration!
-    public var onExit: (() -> ())?
+    var onExit: (() -> ())?
     
     override func viewDidLoad() {
         super.viewDidLoad()

--- a/Sources/Kevin/Accounts/LinkingSession/KevinAccountLinkingSession.swift
+++ b/Sources/Kevin/Accounts/LinkingSession/KevinAccountLinkingSession.swift
@@ -158,7 +158,7 @@ final public class KevinAccountLinkingSession {
             selectedCountry: selectedCountry ?? configuration.preselectedCountry,
             linkingType: configuration.linkingType
         )
-        controller.onExit = { [weak self] in
+        controller.onClose = { [weak self] in
             self?.delegate?.onKevinAccountLinkingCanceled(error: KevinCancelationError())
         }
         return controller

--- a/Sources/Kevin/Accounts/LinkingSession/KevinAccountLinkingSession.swift
+++ b/Sources/Kevin/Accounts/LinkingSession/KevinAccountLinkingSession.swift
@@ -132,7 +132,7 @@ final public class KevinAccountLinkingSession {
             )
         }
         controller.onExit = { [weak self] in
-            self?.delegate?.onKevinAccountLinkingCanceled(error: KevinCancelationError(description: "User has canceled the flow!"))
+            self?.delegate?.onKevinAccountLinkingCanceled(error: KevinCancelationError())
         }
         return KevinNavigationViewController(rootViewController: controller)
     }
@@ -142,28 +142,25 @@ final public class KevinAccountLinkingSession {
     private func initializeAccountLinkingConfirmation(
         configuration: KevinAccountLinkingSessionConfiguration
     ) -> UINavigationController {
-        let controller = KevinAccountLinkingViewController()
-        controller.configuration = KevinAccountLinkingConfiguration(
-            state: configuration.state,
-            selectedBankId: configuration.preselectedBank,
-            selectedCountry: configuration.preselectedCountry,
-            linkingType: configuration.linkingType
-        )
+        let controller = initializeAccountLinkingConfirmationController(configuration: configuration)
         return KevinNavigationViewController(rootViewController: controller)
     }
     
     private func initializeAccountLinkingConfirmationController(
         configuration: KevinAccountLinkingSessionConfiguration,
         selectedBank: String? = nil,
-        selectedCountry: KevinCountry?
+        selectedCountry: KevinCountry? = nil
     ) -> UIViewController {
         let controller = KevinAccountLinkingViewController()
         controller.configuration = KevinAccountLinkingConfiguration(
             state: configuration.state,
             selectedBankId: selectedBank ?? configuration.preselectedBank,
-            selectedCountry: selectedCountry,
+            selectedCountry: selectedCountry ?? configuration.preselectedCountry,
             linkingType: configuration.linkingType
         )
+        controller.onExit = { [weak self] in
+            self?.delegate?.onKevinAccountLinkingCanceled(error: KevinCancelationError())
+        }
         return controller
     }
 }

--- a/Sources/Kevin/Core/Errors/KevinCancelationError.swift
+++ b/Sources/Kevin/Core/Errors/KevinCancelationError.swift
@@ -8,4 +8,8 @@
 
 import Foundation
 
-public class KevinCancelationError: KevinError { }
+public class KevinCancelationError: KevinError {
+    convenience init() {
+        self.init(description: "User has canceled the flow!")
+    }
+}

--- a/Sources/Kevin/InAppPayments/PaymentSession/KevinPaymentSession.swift
+++ b/Sources/Kevin/InAppPayments/PaymentSession/KevinPaymentSession.swift
@@ -101,7 +101,7 @@ final public class KevinPaymentSession {
             )
         }
         controller.onExit = { [weak self] in
-            self?.delegate?.onKevinPaymentCanceled(error: KevinCancelationError(description: "User has canceled the flow!"))
+            self?.delegate?.onKevinPaymentCanceled(error: KevinCancelationError())
         }
         return KevinNavigationViewController(rootViewController: controller)
     }
@@ -115,7 +115,7 @@ final public class KevinPaymentSession {
             exitSlug: "dialog_exit_confirmation_payments_message"
         )
         controller.onExit = { [weak self] in
-            self?.delegate?.onKevinPaymentCanceled(error: KevinCancelationError(description: "User has canceled the flow!"))
+            self?.delegate?.onKevinPaymentCanceled(error: KevinCancelationError())
         }
         return KevinNavigationViewController(rootViewController: controller)
     }


### PR DESCRIPTION
When country and bank selection is skipped user is navigated directly to account linking screen. 
If that screen gets dismissed, delegate does not get notified. 