### PR TITLE
MOBILE-2474 Not present callback URL in the webview

### DIFF
--- a/Sources/Kevin/Accounts/AccountLinking/KevinAccountLinkingIntent.swift
+++ b/Sources/Kevin/Accounts/AccountLinking/KevinAccountLinkingIntent.swift
@@ -21,11 +21,11 @@ internal class KevinAccountLinkingIntent: IKevinIntent {
 
     internal class HandleLinkingCompleted: KevinAccountLinkingIntent {
         
-        public let url: URL
+        public let url: URL?
         public let error: Error?
         public let configuration: KevinAccountLinkingConfiguration
         
-        init(url: URL, error: Error?, configuration: KevinAccountLinkingConfiguration) {
+        init(url: URL?, error: Error?, configuration: KevinAccountLinkingConfiguration) {
             self.url = url
             self.error = error
             self.configuration = configuration

--- a/Sources/Kevin/Accounts/AccountLinking/KevinAccountLinkingView.swift
+++ b/Sources/Kevin/Accounts/AccountLinking/KevinAccountLinkingView.swift
@@ -33,7 +33,7 @@ internal class KevinAccountLinkingView: KevinView<KevinAccountLinkingState> {
             addSubview(webView)
             webView.translatesAutoresizingMaskIntoConstraints = false
             webView.fill(in: self)
-            webView.paymentCompletedCallback = { [weak self] url, error in
+            webView.completedCallback = { [weak self] url, error in
                 self?.delegate?.onAccountLinkingCompleted(callbackUrl: url, error: error)
             }
         } catch {

--- a/Sources/Kevin/Accounts/AccountLinking/KevinAccountLinkingView.swift
+++ b/Sources/Kevin/Accounts/AccountLinking/KevinAccountLinkingView.swift
@@ -13,101 +13,31 @@ internal class KevinAccountLinkingView: KevinView<KevinAccountLinkingState> {
     
     weak var delegate: KevinAccountLinkingViewDelegate?
     
-    private let webView = WKWebView()
-    private let loadingIndicator = UIActivityIndicatorView()
+    private var webView: KevinWebView?
     
     override func render(state: KevinAccountLinkingState) {
-        webView.load(URLRequest(url: state.bankRedirectUrl))
+        webView?.load(URLRequest(url: state.bankRedirectUrl))
     }
     
     override func viewDidLoad() {
         backgroundColor = Kevin.shared.theme.generalStyle.primaryBackgroundColor
         initWebView()
-        initLoadingIndicator()
     }
     
     private func initWebView() {
-        addSubview(webView)
-        webView.commonInit()
-        webView.translatesAutoresizingMaskIntoConstraints = false
-        webView.fill(in: self)
-        webView.navigationDelegate = self
-    }
-    
-    private func initLoadingIndicator() {
-        addSubview(loadingIndicator)
-        loadingIndicator.translatesAutoresizingMaskIntoConstraints = false
-        loadingIndicator.center(in: self)
-        loadingIndicator.startAnimating()
-    }
-}
-
-extension KevinAccountLinkingView: WKNavigationDelegate {
-    
-    func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
-        loadingIndicator.stopAnimating()
-        guard let url = webView.url else {
-            return
-        }
         do {
             let callbackUrl = try KevinAccountsPlugin.shared.getCallbackUrl()
-            if url.absoluteString.starts(with: callbackUrl.absoluteString) {
-                delegate?.onAccountLinkingCompleted(callbackUrl: url, error: nil)
+            let webView = KevinWebView(callbackURL: callbackUrl)
+            self.webView = webView
+            
+            addSubview(webView)
+            webView.translatesAutoresizingMaskIntoConstraints = false
+            webView.fill(in: self)
+            webView.paymentCompletedCallback = { [weak self] url, error in
+                self?.delegate?.onAccountLinkingCompleted(callbackUrl: url, error: error)
             }
         } catch {
-            delegate?.onAccountLinkingCompleted(callbackUrl: url, error: error)
+            delegate?.onAccountLinkingCompleted(callbackUrl: nil, error: error)
         }
-    }
-    
-    func webView(
-        _ webView: WKWebView,
-        decidePolicyFor navigationAction: WKNavigationAction,
-        decisionHandler: @escaping (WKNavigationActionPolicy) -> Void
-    ) {
-        if shouldProcessExternally(url: navigationAction.request.url) {
-            if #available(iOS 10.0, *) {
-                UIApplication.shared.open(
-                    navigationAction.request.url!,
-                    options: [.universalLinksOnly: true]
-                ) { isSuccess in
-                    if isSuccess {
-                        decisionHandler(.cancel)
-                    } else {
-                        decisionHandler(.allow)
-                    }
-                }
-            } else {
-                decisionHandler(.allow)
-            }
-        } else {
-            decisionHandler(.allow)
-        }
-    }
-
-    func webView(_ webView: WKWebView, didFailProvisionalNavigation: WKNavigation!, withError error: Error) {
-        // Ignore error of another request is made before the previous request is completed.
-        guard let url = webView.url, (error as NSError).code != NSURLErrorCancelled else {
-            return
-        }
-
-        delegate?.onAccountLinkingCompleted(callbackUrl: url, error: error)
-    }
-    
-    private func shouldProcessExternally(url: URL?) -> Bool {
-        guard let url = url else {
-            return false
-        }
-        
-        if url.scheme == "tel" || url.scheme == "mailto" {
-            return true
-        }
-        
-        if Kevin.shared.isDeepLinkingEnabled {
-            if (url.scheme == "http" || url.scheme == "https") {
-                return url.host != KevinApiPaths.host
-            }
-        }
-        
-        return false
     }
 }

--- a/Sources/Kevin/Accounts/AccountLinking/KevinAccountLinkingViewController.swift
+++ b/Sources/Kevin/Accounts/AccountLinking/KevinAccountLinkingViewController.swift
@@ -50,7 +50,7 @@ internal class KevinAccountLinkingViewController :
 
 extension KevinAccountLinkingViewController: KevinAccountLinkingViewDelegate {
     
-    func onAccountLinkingCompleted(callbackUrl: URL, error: Error?) {
+    func onAccountLinkingCompleted(callbackUrl: URL?, error: Error?) {
         guard let navigationController = navigationController else {
             self.offerIntent(
                 KevinAccountLinkingIntent.HandleLinkingCompleted(url: callbackUrl, error: error, configuration: self.configuration)

--- a/Sources/Kevin/Accounts/AccountLinking/KevinAccountLinkingViewDelegate.swift
+++ b/Sources/Kevin/Accounts/AccountLinking/KevinAccountLinkingViewDelegate.swift
@@ -9,5 +9,5 @@
 import Foundation
 
 protocol KevinAccountLinkingViewDelegate: AnyObject {
-    func onAccountLinkingCompleted(callbackUrl: URL, error: Error?)
+    func onAccountLinkingCompleted(callbackUrl: URL?, error: Error?)
 }

--- a/Sources/Kevin/Accounts/AccountLinking/KevinAccountLinkingViewModel.swift
+++ b/Sources/Kevin/Accounts/AccountLinking/KevinAccountLinkingViewModel.swift
@@ -34,7 +34,7 @@ internal class KevinAccountLinkingViewModel : KevinViewModel<KevinAccountLinking
     }
     
     private func notifyLinkingCompletion(
-        callbackUrl: URL,
+        callbackUrl: URL?,
         error: Error?,
         configuration: KevinAccountLinkingConfiguration
     ) {
@@ -42,11 +42,11 @@ internal class KevinAccountLinkingViewModel : KevinViewModel<KevinAccountLinking
             KevinAccountLinkingSession.shared.notifyAccountLinkingCancelation(error: error)
             return
         }
-        guard let status = callbackUrl["status"] else {
+        guard let status = callbackUrl?["status"] else {
             return
         }
         if status == "success" {
-            if let code = callbackUrl["code"] {
+            if let code = callbackUrl?["code"] {
                 KevinAccountLinkingSession.shared.notifyAccountLinkingCompletion(
                     authorizationCode: code,
                     bankId: configuration.selectedBankId,

--- a/Sources/Kevin/Accounts/KevinAccountsPlugin.swift
+++ b/Sources/Kevin/Accounts/KevinAccountsPlugin.swift
@@ -27,7 +27,7 @@ public class KevinAccountsPlugin: KevinPlugin {
     
     public func getCallbackUrl() throws -> URL {
         guard let configuration = configuration else {
-            throw KevinError(description: "KevinAccountsPlugin was not configured!")
+            throw KevinError(description: "CallbackUrl in KevinAccountsPlugin was not configured!")
         }
         return configuration.callbackUrl
     }

--- a/Sources/Kevin/Core/Custom/KevinWebView.swift
+++ b/Sources/Kevin/Core/Custom/KevinWebView.swift
@@ -1,0 +1,90 @@
+//
+//  KevinWebView.swift
+//  
+//
+//  Created by Arthur Alehna on 19/04/2023.
+//  Copyright © 2023 kevin.. All rights reserved.
+//
+
+import WebKit
+
+internal class KevinWebView: WKWebView, WKNavigationDelegate {
+    
+    typealias CompletedCallback = (URL, Error?) -> ()
+    var completedCallback: CompletedCallback? = nil
+    
+    private let loadingIndicator = UIActivityIndicatorView()
+    private let callbackURL: URL
+    
+    init(callbackURL: URL) {
+        self.callbackURL = callbackURL
+        super.init(frame: .zero, configuration: .init())
+        
+        navigationDelegate = self
+        commonInit()
+        initLoadingIndicator()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    private func initLoadingIndicator() {
+        addSubview(loadingIndicator)
+        loadingIndicator.translatesAutoresizingMaskIntoConstraints = false
+        loadingIndicator.center(in: self)
+        loadingIndicator.startAnimating()
+    }
+
+    func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
+        loadingIndicator.stopAnimating()
+    }
+    
+    func webView(
+        _ webView: WKWebView,
+        decidePolicyFor navigationAction: WKNavigationAction,
+        decisionHandler: @escaping (WKNavigationActionPolicy) -> Void
+    ) {
+        guard let url = navigationAction.request.url else {
+            decisionHandler(.allow)
+            return
+        }
+
+        if shouldProcessExternally(url: url) {
+            if #available(iOS 10.0, *) {
+                UIApplication.shared.open(url, options: [.universalLinksOnly: true]) { isSuccess in
+                    if isSuccess {
+                        decisionHandler(.cancel)
+                    } else {
+                        decisionHandler(.allow)
+                    }
+                }
+            } else {
+                decisionHandler(.allow)
+            }
+        } else {
+            if isCallbackURL(url: url) {
+                decisionHandler(.cancel)
+                completedCallback?(url, nil)
+            } else {
+                decisionHandler(.allow)
+            }
+        }
+    }
+    
+    private func shouldProcessExternally(url: URL) -> Bool {
+        if url.scheme == "tel" || url.scheme == "mailto" {
+            return true
+        }
+        
+        if Kevin.shared.isDeepLinkingEnabled && (url.scheme == "http" || url.scheme == "https") {
+            return url.host != KevinApiPaths.host
+        }
+        
+        return false
+    }
+    
+    private func isCallbackURL(url: URL) -> Bool {
+        url.absoluteString.starts(with: callbackURL.absoluteString)
+    }
+}

--- a/Sources/Kevin/InAppPayments/PaymentConfirmation/KevinPaymentConfirmationView.swift
+++ b/Sources/Kevin/InAppPayments/PaymentConfirmation/KevinPaymentConfirmationView.swift
@@ -26,7 +26,7 @@ internal class KevinPaymentConfirmationView: KevinView<KevinPaymentConfirmationS
     
     private func initWebView() {
         do {
-            let callbackUrl = try KevinAccountsPlugin.shared.getCallbackUrl()
+            let callbackUrl = try KevinInAppPaymentsPlugin.shared.getCallbackUrl()
             let webView = KevinWebView(callbackURL: callbackUrl)
             self.webView = webView
             

--- a/Sources/Kevin/InAppPayments/PaymentConfirmation/KevinPaymentConfirmationView.swift
+++ b/Sources/Kevin/InAppPayments/PaymentConfirmation/KevinPaymentConfirmationView.swift
@@ -33,7 +33,7 @@ internal class KevinPaymentConfirmationView: KevinView<KevinPaymentConfirmationS
             addSubview(webView)
             webView.translatesAutoresizingMaskIntoConstraints = false
             webView.fill(in: self)
-            webView.paymentCompletedCallback = { [weak self] url, error in
+            webView.completedCallback = { [weak self] url, error in
                 self?.delegate?.onPaymentCompleted(callbackUrl: url, error: error)
             }
         } catch {

--- a/Sources/Kevin/InAppPayments/PaymentConfirmation/KevinPaymentConfirmationView.swift
+++ b/Sources/Kevin/InAppPayments/PaymentConfirmation/KevinPaymentConfirmationView.swift
@@ -13,92 +13,31 @@ internal class KevinPaymentConfirmationView: KevinView<KevinPaymentConfirmationS
     
     weak var delegate: KevinPaymentConfirmationViewDelegate?
     
-    private let webView = WKWebView()
-    private let loadingIndicator = UIActivityIndicatorView()
+    private var webView: KevinWebView?
     
     override func render(state: KevinPaymentConfirmationState) {
-        webView.load(URLRequest(url: state.url))
+        webView?.load(URLRequest(url: state.url))
     }
     
     override func viewDidLoad() {
         backgroundColor = Kevin.shared.theme.generalStyle.primaryBackgroundColor
         initWebView()
-        initLoadingIndicator()
     }
     
     private func initWebView() {
-        addSubview(webView)
-        webView.commonInit()
-        webView.translatesAutoresizingMaskIntoConstraints = false
-        webView.fill(in: self)
-        webView.navigationDelegate = self
-    }
-    
-    private func initLoadingIndicator() {
-        addSubview(loadingIndicator)
-        loadingIndicator.translatesAutoresizingMaskIntoConstraints = false
-        loadingIndicator.center(in: self)
-        loadingIndicator.startAnimating()
-    }
-}
-
-extension KevinPaymentConfirmationView: WKNavigationDelegate {
-    
-    func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
-        loadingIndicator.stopAnimating()
-        guard let url = webView.url else {
-            return
-        }
         do {
-            let callbackUrl = try KevinInAppPaymentsPlugin.shared.getCallbackUrl()
-            if url.absoluteString.starts(with: callbackUrl.absoluteString) {
-                delegate?.onPaymentCompleted(callbackUrl: url, error: nil)
+            let callbackUrl = try KevinAccountsPlugin.shared.getCallbackUrl()
+            let webView = KevinWebView(callbackURL: callbackUrl)
+            self.webView = webView
+            
+            addSubview(webView)
+            webView.translatesAutoresizingMaskIntoConstraints = false
+            webView.fill(in: self)
+            webView.paymentCompletedCallback = { [weak self] url, error in
+                self?.delegate?.onPaymentCompleted(callbackUrl: url, error: error)
             }
         } catch {
-            delegate?.onPaymentCompleted(callbackUrl: url, error: error)
+            delegate?.onPaymentCompleted(callbackUrl: nil, error: error)
         }
-    }
-    
-    func webView(
-        _ webView: WKWebView,
-        decidePolicyFor navigationAction: WKNavigationAction,
-        decisionHandler: @escaping (WKNavigationActionPolicy) -> Void
-    ) {
-        if shouldProcessExternally(url: navigationAction.request.url) {
-            if #available(iOS 10.0, *) {
-                UIApplication.shared.open(
-                    navigationAction.request.url!,
-                    options: [.universalLinksOnly: true]
-                ) { isSuccess in
-                    if isSuccess {
-                        decisionHandler(.cancel)
-                    } else {
-                        decisionHandler(.allow)
-                    }
-                }
-            } else {
-                decisionHandler(.allow)
-            }
-        } else {
-            decisionHandler(.allow)
-        }
-    }
-    
-    func shouldProcessExternally(url: URL?) -> Bool {
-        guard let url = url else {
-            return false
-        }
-        
-        if url.scheme == "tel" || url.scheme == "mailto" {
-            return true
-        }
-        
-        if Kevin.shared.isDeepLinkingEnabled {
-            if (url.scheme == "http" || url.scheme == "https") {
-                return url.host != KevinApiPaths.host
-            }
-        }
-        
-        return false
     }
 }

--- a/Sources/Kevin/InAppPayments/PaymentConfirmation/KevinPaymentConfirmationViewController.swift
+++ b/Sources/Kevin/InAppPayments/PaymentConfirmation/KevinPaymentConfirmationViewController.swift
@@ -90,7 +90,7 @@ internal class KevinPaymentConfirmationViewController :
 
 extension KevinPaymentConfirmationViewController: KevinPaymentConfirmationViewDelegate {
     
-    func onPaymentCompleted(callbackUrl: URL, error: Error?) {
+    func onPaymentCompleted(callbackUrl: URL?, error: Error?) {
         guard let navigationController = navigationController else {
             self.offerIntent(
                 KevinPaymentConfirmationIntent.HandlePaymentCompleted(url: callbackUrl, error: error)

--- a/Sources/Kevin/InAppPayments/PaymentConfirmation/KevinPaymentConfirmationViewDelegate.swift
+++ b/Sources/Kevin/InAppPayments/PaymentConfirmation/KevinPaymentConfirmationViewDelegate.swift
@@ -9,5 +9,5 @@
 import Foundation
 
 internal protocol KevinPaymentConfirmationViewDelegate: AnyObject {
-    func onPaymentCompleted(callbackUrl: URL, error: Error?)
+    func onPaymentCompleted(callbackUrl: URL?, error: Error?)
 }

--- a/demo/KevinDemo/UseCases/LinkAccountUseCase.swift
+++ b/demo/KevinDemo/UseCases/LinkAccountUseCase.swift
@@ -29,9 +29,9 @@ public class LinkAccountUseCase: BasePublishingUseCase<KevinInitiationState>, Ke
                     configuration: KevinAccountLinkingSessionConfiguration.Builder(
                         state: state.state
                     )
-                        .setPreselectedCountry(.lithuania)
-                        .setSkipBankSelection(false)
-                        .build()
+                    .setPreselectedCountry(.lithuania)
+                    .setSkipBankSelection(false)
+                    .build()
                 )
             } catch {
                 self?.subject.send(completion: .failure(error))


### PR DESCRIPTION
Fixing the issue that configured callback url is briefly visible during the payment and account linking. Now check for the callback is performed not when page is loaded but when delegate asks permission for navigation. 