### PR TITLE
MOBILE-2501: Set default country depending on locale

### DIFF
--- a/Sources/Kevin/Accounts/LinkingSession/KevinAccountLinkingSession.swift
+++ b/Sources/Kevin/Accounts/LinkingSession/KevinAccountLinkingSession.swift
@@ -71,13 +71,19 @@ final public class KevinAccountLinkingSession {
                     bankCode: configuration.preselectedBank!,
                     country: configuration.preselectedCountry
                 ) { [weak self] bank in
-                    if bank == nil {
+                    guard let bank = bank else {
                         self?.delegate?.onKevinAccountLinkingCanceled(error: KevinError(description: "Preselected bank is not available!"))
-                    } else {
-                        self?.delegate?.onKevinAccountLinkingStarted(
-                            controller: self!.initializeAccountLinkingConfirmation(configuration: configuration)
-                        )
+                        return
                     }
+                    
+                    if !bank.isAccountLinkingSupported {
+                        self?.delegate?.onKevinAccountLinkingCanceled(error: KevinError(description: "Preselected bank does not support account linking."))
+                        return
+                    }
+                    
+                    self?.delegate?.onKevinAccountLinkingStarted(
+                        controller: self!.initializeAccountLinkingConfirmation(configuration: configuration)
+                    )
                 }
             } else {
                 do {

--- a/Sources/Kevin/Accounts/LinkingSession/KevinAccountLinkingSession.swift
+++ b/Sources/Kevin/Accounts/LinkingSession/KevinAccountLinkingSession.swift
@@ -112,7 +112,7 @@ final public class KevinAccountLinkingSession {
     ) throws -> UINavigationController {
         let controller = KevinBankSelectionViewController()
         controller.configuration = KevinBankSelectionConfiguration(
-            selectedCountry: configuration.preselectedCountry ?? KevinCountry.lithuania,
+            selectedCountry: configuration.preselectedCountry ?? CountryHelper.defaultCountry,
             isCountrySelectionDisabled: configuration.disableCountrySelection,
             countryFilter: configuration.countryFilter,
             selectedBankId: configuration.preselectedBank,

--- a/Sources/Kevin/Core/Errors/KevinError.swift
+++ b/Sources/Kevin/Core/Errors/KevinError.swift
@@ -16,3 +16,9 @@ public class KevinError: Error {
         self.description = description
     }
 }
+
+extension KevinError: LocalizedError {
+    public var errorDescription: String? {
+        return description
+    }
+}

--- a/Sources/Kevin/Core/Helpers/CountryHelper.swift
+++ b/Sources/Kevin/Core/Helpers/CountryHelper.swift
@@ -11,7 +11,7 @@ import CoreTelephony
 
 internal struct CountryHelper {
     static var defaultCountry: KevinCountry {
-       let detected = [countryBasedOnSIM(), countryBasedOnLocale()]
+        let detected = [countryBasedOnSIM(), countryBasedOnLocale()]
             .compactMap { $0 }
             .first
         

--- a/Sources/Kevin/Core/Helpers/CountryHelper.swift
+++ b/Sources/Kevin/Core/Helpers/CountryHelper.swift
@@ -1,0 +1,44 @@
+//
+//  Kevin.swift
+//  kevin.iOS
+//
+//  Created by Kacper Dziubek on 12/06/2023.
+//  Copyright © 2021 kevin.. All rights reserved.
+//
+
+import Foundation
+import CoreTelephony
+
+internal struct CountryHelper {
+    static var defaultCountry: KevinCountry {
+       let detected = [countryBasedOnSIM(), countryBasedOnLocale()]
+            .compactMap { $0 }
+            .first
+        
+        return detected ?? KevinCountry.lithuania
+    }
+    
+    private static func countryBasedOnSIM() -> KevinCountry? {
+        if #available(iOS 12.0, *) {
+            let networkProviders = CTTelephonyNetworkInfo().serviceSubscriberCellularProviders
+            guard
+                let countryCode = networkProviders?.first?.value.isoCountryCode,
+                let kevinCountry = KevinCountry(rawValue: countryCode.lowercased())
+            else {
+                return nil
+            }
+            
+            return kevinCountry
+        } else {
+            return nil
+        }
+    }
+    
+    private static func countryBasedOnLocale() -> KevinCountry? {
+        guard let countryCode = (Locale.current as NSLocale).countryCode else {
+            return nil
+        }
+        return KevinCountry(rawValue: countryCode.lowercased())
+        
+    }
+}

--- a/Sources/Kevin/Core/Helpers/CountryHelper.swift
+++ b/Sources/Kevin/Core/Helpers/CountryHelper.swift
@@ -21,8 +21,9 @@ internal struct CountryHelper {
     private static func countryBasedOnSIM() -> KevinCountry? {
         if #available(iOS 12.0, *) {
             let networkProviders = CTTelephonyNetworkInfo().serviceSubscriberCellularProviders
+            let simCountryCodes = networkProviders?.compactMap { $0.value.isoCountryCode }
             guard
-                let countryCode = networkProviders?.first?.value.isoCountryCode,
+                let countryCode = simCountryCodes?.first,
                 let kevinCountry = KevinCountry(rawValue: countryCode.lowercased())
             else {
                 return nil

--- a/Sources/Kevin/InAppPayments/PaymentSession/KevinPaymentSession.swift
+++ b/Sources/Kevin/InAppPayments/PaymentSession/KevinPaymentSession.swift
@@ -85,7 +85,7 @@ final public class KevinPaymentSession {
     ) -> UINavigationController {
         let controller = KevinBankSelectionViewController()
         controller.configuration = KevinBankSelectionConfiguration(
-            selectedCountry: configuration.preselectedCountry ?? KevinCountry.lithuania,
+            selectedCountry: configuration.preselectedCountry ?? CountryHelper.defaultCountry,
             isCountrySelectionDisabled: configuration.disableCountrySelection,
             countryFilter: configuration.countryFilter,
             selectedBankId: configuration.preselectedBank,


### PR DESCRIPTION
**What's new:**

- Set default county based on sim card or locale
- Throw an error if preselected bank does not support account linking
-  Make `KevinError` conform to `LocalizedError` so that using `error?.localizedMessage` shows meaningful messages.