### PR TITLE
MOBILE-2750: Add missing frame customisation params

### DIFF
--- a/Sources/Kevin/Accounts/AccountLinking/KevinAccountLinkingViewModel.swift
+++ b/Sources/Kevin/Accounts/AccountLinking/KevinAccountLinkingViewModel.swift
@@ -27,7 +27,7 @@ internal class KevinAccountLinkingViewModel : KevinViewModel<KevinAccountLinking
         
         onStateChanged(
             KevinAccountLinkingState(
-                bankRedirectUrl: appendUrlParameters(urlString: baseUrl),
+                bankRedirectUrl: FrameCustomisationHelper.appendUrlParameters(urlString: baseUrl),
                 accountLinkingType: configuration.linkingType
             )
         )
@@ -63,29 +63,5 @@ internal class KevinAccountLinkingViewModel : KevinViewModel<KevinAccountLinking
                 error: KevinError(description: "Account linking was canceled!")
             )
         }
-    }
-    
-    private func appendUrlParameters(urlString: String) -> URL {
-        let customStyle = [
-            "bc": Kevin.shared.theme.generalStyle.primaryBackgroundColor.hexString,
-            "bsc": Kevin.shared.theme.generalStyle.primaryBackgroundColor.hexString,
-            "hc": Kevin.shared.theme.generalStyle.primaryTextColor.hexString,
-            "fc": Kevin.shared.theme.generalStyle.primaryTextColor.hexString,
-            "bic": UIApplication.shared.isLightThemedInterface ? "default" : "white",
-            "dbc": Kevin.shared.theme.mainButtonStyle.backgroundColor.hexString
-        ]
-
-        let jsonData = try! JSONEncoder().encode(customStyle)
-        let jsonString = String(data: jsonData, encoding: String.Encoding.utf8)!
-
-        let queryItems = [
-            URLQueryItem(name: "lang", value: Kevin.shared.locale.identifier.lowercased()),
-            URLQueryItem(name: "cs", value: jsonString)
-        ]
-        var urlComponents = URLComponents(string: urlString)!
-        urlComponents.queryItems = queryItems
-        let result = urlComponents.url!
-        
-        return result
     }
 }

--- a/Sources/Kevin/Core/Helpers/FrameCustomisationHelper.swift
+++ b/Sources/Kevin/Core/Helpers/FrameCustomisationHelper.swift
@@ -1,0 +1,74 @@
+//
+//  Kevin.swift
+//  kevin.iOS
+//
+//  Created by Kacper Dziubek on 28/06/2023.
+//  Copyright © 2021 kevin.. All rights reserved.
+//
+
+import Foundation
+import UIKit
+
+internal struct FrameCustomisationHelper {
+    static func appendUrlParameters(urlString: String) -> URL {
+        let queryItems = [
+            URLQueryItem(name: "lang", value: Kevin.shared.locale.identifier.lowercased()),
+            URLQueryItem(name: "cs", value: customStyleJsonString)
+        ]
+        var urlComponents = URLComponents(string: urlString)!
+        urlComponents.queryItems = queryItems
+        let result = urlComponents.url!
+
+        return result
+    }
+
+    private static var customStyleJsonString: String {
+        let theme = Kevin.shared.theme
+        let customStyle = CustomStyle(
+            backgroundColor: theme.generalStyle.primaryBackgroundColor.hexString,
+            baseColor: theme.generalStyle.primaryBackgroundColor.hexString,
+            headingsColor: theme.generalStyle.primaryTextColor.hexString,
+            fontColor: theme.generalStyle.primaryTextColor.hexString,
+            bankIconColor: UIApplication.shared.isLightThemedInterface ? "default" : "white",
+            defaultButtonColor: theme.mainButtonStyle.backgroundColor.hexString,
+            defaultButtonFontColor: theme.mainButtonStyle.titleLabelTextColor.hexString,
+            buttonRadius: "\(theme.mainButtonStyle.cornerRadius)px",
+            inputBorderColor: theme.generalStyle.primaryTextColor.hexString,
+            customLayout: customLayoutElements
+        )
+
+        let jsonData = try! JSONEncoder().encode(customStyle)
+        return String(data: jsonData, encoding: String.Encoding.utf8)!
+    }
+
+    private struct CustomStyle: Encodable {
+        let backgroundColor: String
+        let baseColor: String
+        let headingsColor: String
+        let fontColor: String
+        let bankIconColor: String
+        let defaultButtonColor: String
+        let defaultButtonFontColor: String
+        let buttonRadius: String
+        let inputBorderColor: String
+        let customLayout: [String]
+
+        enum CodingKeys: String, CodingKey {
+            case backgroundColor = "bc"
+            case baseColor = "bsc"
+            case headingsColor = "hc"
+            case fontColor = "fc"
+            case bankIconColor = "bic"
+            case defaultButtonColor = "dbc"
+            case defaultButtonFontColor = "dbfc"
+            case buttonRadius = "br"
+            case inputBorderColor = "ibc"
+            case customLayout = "cl"
+
+        }
+    }
+
+    private static var customLayoutElements: [String] {
+        return ["hl"]
+    }
+}

--- a/Sources/Kevin/Core/Helpers/FrameCustomisationHelper.swift
+++ b/Sources/Kevin/Core/Helpers/FrameCustomisationHelper.swift
@@ -34,7 +34,7 @@ internal struct FrameCustomisationHelper {
             defaultButtonFontColor: theme.mainButtonStyle.titleLabelTextColor.hexString,
             buttonRadius: "\(theme.mainButtonStyle.cornerRadius)px",
             inputBorderColor: theme.generalStyle.primaryTextColor.hexString,
-            customLayout: customLayoutElements
+            customLayout: ["hl"]
         )
 
         let jsonData = try! JSONEncoder().encode(customStyle)
@@ -64,11 +64,6 @@ internal struct FrameCustomisationHelper {
             case buttonRadius = "br"
             case inputBorderColor = "ibc"
             case customLayout = "cl"
-
         }
-    }
-
-    private static var customLayoutElements: [String] {
-        return ["hl"]
     }
 }

--- a/Sources/Kevin/InAppPayments/CardPayment/KevinCardPaymentViewModel.swift
+++ b/Sources/Kevin/InAppPayments/CardPayment/KevinCardPaymentViewModel.swift
@@ -46,7 +46,7 @@ internal class KevinCardPaymentViewModel : KevinViewModel<KevinCardPaymentState,
         
         self.configuration = configuration
         
-        let confirmationUrl = appendUrlParameters(
+        let confirmationUrl = FrameCustomisationHelper.appendUrlParameters(
             urlString: String(format: KevinApiPaths.cardPaymentUrl, configuration.paymentId, Kevin.shared.locale.identifier.lowercased())
         )
                 
@@ -175,29 +175,5 @@ internal class KevinCardPaymentViewModel : KevinViewModel<KevinCardPaymentState,
             }
             flowHasBeenProcessed = true
         }
-    }
-    
-    private func appendUrlParameters(urlString: String) -> URL {
-        let customStyle = [
-            "bc": Kevin.shared.theme.generalStyle.primaryBackgroundColor.hexString,
-            "bsc": Kevin.shared.theme.generalStyle.primaryBackgroundColor.hexString,
-            "hc": Kevin.shared.theme.generalStyle.primaryTextColor.hexString,
-            "fc": Kevin.shared.theme.generalStyle.primaryTextColor.hexString,
-            "bic": UIApplication.shared.isLightThemedInterface ? "default" : "white",
-            "dbc": Kevin.shared.theme.mainButtonStyle.backgroundColor.hexString
-        ]
-
-        let jsonData = try! JSONEncoder().encode(customStyle)
-        let jsonString = String(data: jsonData, encoding: String.Encoding.utf8)!
-
-        let queryItems = [
-            URLQueryItem(name: "lang", value: Kevin.shared.locale.identifier.lowercased()),
-            URLQueryItem(name: "cs", value: jsonString)
-        ]
-        var urlComponents = URLComponents(string: urlString)!
-        urlComponents.queryItems = queryItems
-        let result = urlComponents.url!
-        
-        return result
     }
 }

--- a/Sources/Kevin/InAppPayments/PaymentConfirmation/KevinPaymentConfirmationViewModel.swift
+++ b/Sources/Kevin/InAppPayments/PaymentConfirmation/KevinPaymentConfirmationViewModel.swift
@@ -78,26 +78,6 @@ internal class KevinPaymentConfirmationViewModel : KevinViewModel<KevinPaymentCo
     }
     
     private func appendUrlParameters(urlString: String) -> URL {
-        let customStyle = [
-            "bc": Kevin.shared.theme.generalStyle.primaryBackgroundColor.hexString,
-            "bsc": Kevin.shared.theme.generalStyle.primaryBackgroundColor.hexString,
-            "hc": Kevin.shared.theme.generalStyle.primaryTextColor.hexString,
-            "fc": Kevin.shared.theme.generalStyle.primaryTextColor.hexString,
-            "bic": UIApplication.shared.isLightThemedInterface ? "default" : "white",
-            "dbc": Kevin.shared.theme.mainButtonStyle.backgroundColor.hexString
-        ]
-
-        let jsonData = try! JSONEncoder().encode(customStyle)
-        let jsonString = String(data: jsonData, encoding: String.Encoding.utf8)!
-
-        let queryItems = [
-            URLQueryItem(name: "lang", value: Kevin.shared.locale.identifier.lowercased()),
-            URLQueryItem(name: "cs", value: jsonString)
-        ]
-        var urlComponents = URLComponents(string: urlString)!
-        urlComponents.queryItems = queryItems
-        let result = urlComponents.url!
-        
-        return result
+        return FrameCustomisationHelper.appendUrlParameters(urlString: urlString)
     }
 }

--- a/Sources/Kevin/InAppPayments/PaymentConfirmation/KevinPaymentConfirmationViewModel.swift
+++ b/Sources/Kevin/InAppPayments/PaymentConfirmation/KevinPaymentConfirmationViewModel.swift
@@ -24,29 +24,30 @@ internal class KevinPaymentConfirmationViewModel : KevinViewModel<KevinPaymentCo
     }
     
     private func initialize(_ configuration: KevinPaymentConfirmationConfiguration) {
-        var confirmationUrl: URL!
+        var confirmationUrlString: String!
         if configuration.paymentType == .card {
-            confirmationUrl = appendUrlParameters(urlString: String(
+            confirmationUrlString =  String(
                 format: KevinApiPaths.cardPaymentUrl,
                 configuration.paymentId,
                 Kevin.shared.locale.identifier.lowercased()
-            ))
+            )
         } else if configuration.paymentType == .bank {
             if configuration.skipAuthentication {
-                confirmationUrl = appendUrlParameters(urlString: String(
+                confirmationUrlString = String(
                     format: KevinApiPaths.bankPaymentAuthenticatedUrl,
                     configuration.paymentId,
                     Kevin.shared.locale.identifier.lowercased()
-                ))
+                )
             } else {
-                confirmationUrl = appendUrlParameters(urlString: String(
+                confirmationUrlString = String(
                     format: KevinApiPaths.bankPaymentUrl,
                     configuration.paymentId,
                     configuration.selectedBank!,
                     Kevin.shared.locale.identifier.lowercased()
-                ))
+                )
             }
         }
+        let confirmationUrl = FrameCustomisationHelper.appendUrlParameters(urlString: confirmationUrlString)
         onStateChanged(KevinPaymentConfirmationState(url: confirmationUrl))
     }
     
@@ -75,9 +76,5 @@ internal class KevinPaymentConfirmationViewModel : KevinViewModel<KevinPaymentCo
             }
             flowHasBeenProcessed = true
         }
-    }
-    
-    private func appendUrlParameters(urlString: String) -> URL {
-        return FrameCustomisationHelper.appendUrlParameters(urlString: urlString)
     }
 }


### PR DESCRIPTION
**What's new**
- Remove code duplication and add `FrameCustomisationHelper` responsible for preparing frame customisation
- Hide language selection 
- Add support for  missing frame customisation parameters: `dbfc` (default button font color), `br` (button radius), `ibc` (input border color)