### PR TITLE
MOBILE-3024: Introduce Unit Tests

### DIFF
--- a/Sources/Kevin/Accounts/AccountLinking/KevinAccountLinkingViewModel.swift
+++ b/Sources/Kevin/Accounts/AccountLinking/KevinAccountLinkingViewModel.swift
@@ -53,12 +53,12 @@ internal class KevinAccountLinkingViewModel : KevinViewModel<KevinAccountLinking
                 )
             } else {
                 KevinAccountLinkingSession.shared.notifyAccountLinkingCancelation(
-                    error: KevinError(description: "Account authorizationCode has not been returned!")
+                    error: KevinErrors.accountAuthCodeMissing
                 )
             }
         } else {
             KevinAccountLinkingSession.shared.notifyAccountLinkingCancelation(
-                error: KevinError(description: "Account linking was canceled!")
+                error: KevinErrors.linkingCanceled
             )
         }
     }

--- a/Sources/Kevin/Accounts/AccountLinking/KevinAccountLinkingViewModel.swift
+++ b/Sources/Kevin/Accounts/AccountLinking/KevinAccountLinkingViewModel.swift
@@ -41,6 +41,9 @@ internal class KevinAccountLinkingViewModel : KevinViewModel<KevinAccountLinking
             return
         }
         guard let status = callbackUrl?["status"] else {
+            KevinAccountLinkingSession.shared.notifyAccountLinkingCancelation(
+                error: KevinErrors.unknownLinkingStatus
+            )
             return
         }
         if status == "success" {

--- a/Sources/Kevin/Accounts/KevinAccountsPlugin.swift
+++ b/Sources/Kevin/Accounts/KevinAccountsPlugin.swift
@@ -27,14 +27,14 @@ public class KevinAccountsPlugin: KevinPlugin {
     
     public func getCallbackUrl() throws -> URL {
         guard let configuration = configuration else {
-            throw KevinError(description: "CallbackUrl in KevinAccountsPlugin was not configured!")
+            throw KevinErrors.accountPluginCallbackUrlNotConfigured
         }
         return configuration.callbackUrl
     }
     
     public func shouldExcludeBanksWithoutAccountLinkingSupport() throws -> Bool {
         guard let configuration = configuration else {
-            throw KevinError(description: "KevinAccountsPlugin was not configured!")
+            throw KevinErrors.accountPluginNotConfigured
         }
         return !configuration.showUnsupportedBanks
     }

--- a/Sources/Kevin/Accounts/LinkingSession/KevinAccountLinkingSession.swift
+++ b/Sources/Kevin/Accounts/LinkingSession/KevinAccountLinkingSession.swift
@@ -50,7 +50,7 @@ final public class KevinAccountLinkingSession: NSObject {
                     linkingType: .bank
                 )
             } else {
-                let error = KevinError(description: "Provided preselected bank is not supported")
+                let error = KevinErrors.preselectedBankNotSupported
                 delegate?.onKevinAccountLinkingCanceled(error: error)
             }
         }
@@ -143,11 +143,11 @@ final public class KevinAccountLinkingSession: NSObject {
             completion(selectedBank)
             
         case .invalidFilter:
-            let error = KevinError(description: "Provided bank filter does not contain supported banks")
+            let error = KevinErrors.filterInvalid
             delegate?.onKevinAccountLinkingCanceled(error: error)
             
         case .invalidPreselectedBank:
-            let error = KevinError(description: "Provided preselected bank is not supported")
+            let error = KevinErrors.preselectedBankNotSupported
             delegate?.onKevinAccountLinkingCanceled(error: error)
             
         case .unknown(let error):

--- a/Sources/Kevin/Accounts/LinkingSession/KevinAccountLinkingSession.swift
+++ b/Sources/Kevin/Accounts/LinkingSession/KevinAccountLinkingSession.swift
@@ -135,7 +135,7 @@ final public class KevinAccountLinkingSession: NSObject {
     }
     
     private func onBankConfigurationValidation(
-        status: ValidateBanksConfigurationUseCase.Status,
+        status: BankConfigurationValidationStatus,
         completion: @escaping (ApiBank?) -> Void
     ) {
         switch status {

--- a/Sources/Kevin/Accounts/LinkingSession/KevinAccountLinkingSessionConfiguration.swift
+++ b/Sources/Kevin/Accounts/LinkingSession/KevinAccountLinkingSessionConfiguration.swift
@@ -43,14 +43,14 @@ public class KevinAccountLinkingSessionConfiguration {
         self.confirmInteractiveDismiss = confirmInteractiveDismiss
 
         if skipBankSelection && preselectedBank == nil {
-            throw KevinError(description: "If skipBankSelection is true, preselectedBank must be provided!")
+            throw KevinErrors.preselectedBankNotProvided
         }
         if disableCountrySelection && preselectedCountry == nil {
-            throw KevinError(description: "If disableCountrySelection is true, preselectedCountry must be provided!")
+            throw KevinErrors.preselectedCountryNotProvided
         }
         if let preselectedCountry = preselectedCountry, !countryFilter.isEmpty {
             if !countryFilter.contains(preselectedCountry) {
-                throw KevinError(description: "PreselectedCountry has to be included in countryFilter!")
+                throw KevinErrors.preselectedCountryNoInTheFilter
             }
         }
     }

--- a/Sources/Kevin/Accounts/Networking/KevinAccountsApiClient.swift
+++ b/Sources/Kevin/Accounts/Networking/KevinAccountsApiClient.swift
@@ -8,6 +8,27 @@
 
 import Foundation
 
+internal extension URL {
+
+    static func countries(with token: String) -> URL {
+        apiURL.appendingPathComponent("platform/frame/countries/\(token)")
+    }
+
+    static func banks(with token: String) -> URL {
+        apiURL.appendingPathComponent("platform/frame/banks/\(token)")
+    }
+    
+    private static var apiURL: URL {
+        get {
+            if Kevin.shared.isSandbox {
+                return URL(string: "https://sandbox-api.getkevin.eu/")!
+            } else {
+                return URL(string: "https://api.kevin.eu/")!
+            }
+        }
+    }
+}
+
 public class KevinAccountsApiClient {
     
     public static let shared = KevinAccountsApiClient()
@@ -15,7 +36,7 @@ public class KevinAccountsApiClient {
     public func getSupportedCountries(token: String, completion: @escaping (Array<String>?, Error?) -> Void) {
         KevinApiClient.shared.get(
             type: KevinApiCountryResponse.self,
-            endpoint: "platform/frame/countries/\(token)"
+            url: URL.countries(with: token)
         ) { (response, _, error) in
             completion(response?.countries, error)
         }
@@ -24,8 +45,8 @@ public class KevinAccountsApiClient {
     public func getSupportedBanks(token: String, country: String?, completion: @escaping (Array<ApiBank>?, Error?) -> Void) {
         KevinApiClient.shared.get(
             type: KevinApiBankListResponse.self,
-            endpoint: "platform/frame/banks/\(token)",
-            parameters: ["countryCode":country as Any]
+            url: URL.banks(with: token),
+            parameters: ["countryCode": country]
         ) { (response, _, error) in
             completion(response?.banks, error)
         }

--- a/Sources/Kevin/Core/Errors/KevinError.swift
+++ b/Sources/Kevin/Core/Errors/KevinError.swift
@@ -22,3 +22,9 @@ extension KevinError: LocalizedError {
         return description
     }
 }
+
+extension KevinError: Equatable {
+    public static func == (lhs: KevinError, rhs: KevinError) -> Bool {
+        lhs.description == rhs.description
+    }
+}

--- a/Sources/Kevin/Core/Errors/KevinErrors.swift
+++ b/Sources/Kevin/Core/Errors/KevinErrors.swift
@@ -18,7 +18,8 @@ internal class KevinErrors {
     static let filterInvalid = KevinError(description: "Provided bank filter does not contain supported banks")
     static let preselectedCountryNotProvided = KevinError(description: "If disableCountrySelection is true, preselectedCountry must be provided!")
     static let preselectedCountryNoInTheFilter = KevinError(description: "PreselectedCountry has to be included in countryFilter!")
-    static let unknownPaymetnStatus = KevinError(description: "Unknown payment status received")
+    static let unknownPaymentStatus = KevinError(description: "Unknown payment status received")
+    static let unknownLinkingStatus = KevinError(description: "Unknown account linking status received")
 
     static let linkingCanceled = KevinCancelationError(description: "Account linking was canceled!")
     static let paymentCanceled = KevinCancelationError(description: "Payment was canceled!")

--- a/Sources/Kevin/Core/Errors/KevinErrors.swift
+++ b/Sources/Kevin/Core/Errors/KevinErrors.swift
@@ -1,0 +1,29 @@
+//
+//  KevinErrors.swift
+//  kevin.iOS
+//
+//  Created by Daniel Klinge on 08/09/2023.
+//  Copyright © 2023 kevin.. All rights reserved.
+//
+
+import Foundation
+
+internal class KevinErrors {
+    static let accountPluginCallbackUrlNotConfigured = KevinError(description: "CallbackUrl in KevinAccountsPlugin was not configured!")
+    static let accountPluginNotConfigured = KevinError(description: "KevinAccountsPlugin was not configured!")
+    static let paymentPluginNotConfigured = KevinError(description: "KevinInAppPaymentsPlugin was not configured!")
+    static let accountAuthCodeMissing = KevinError(description: "Account authorizationCode has not been returned!")
+    static let preselectedBankNotSupported = KevinError(description: "Provided preselected bank is not supported")
+    static let preselectedBankNotProvided = KevinError(description: "If skipBankSelection is true, preselectedBank must be provided!")
+    static let filterInvalid = KevinError(description: "Provided bank filter does not contain supported banks")
+    static let preselectedCountryNotProvided = KevinError(description: "If disableCountrySelection is true, preselectedCountry must be provided!")
+    static let preselectedCountryNoInTheFilter = KevinError(description: "PreselectedCountry has to be included in countryFilter!")
+    static let unknownPaymetnStatus = KevinError(description: "Unknown payment status received")
+
+    static let linkingCanceled = KevinCancelationError(description: "Account linking was canceled!")
+    static let paymentCanceled = KevinCancelationError(description: "Payment was canceled!")
+    
+    static func schemeNotInstalled(scheme: String?) -> KevinError {
+        return KevinError(description: "\(scheme ?? "Unknown") is not installed")
+    }
+}

--- a/Sources/Kevin/Core/UseCases/ValidateBanksConfigurationUseCase.swift
+++ b/Sources/Kevin/Core/UseCases/ValidateBanksConfigurationUseCase.swift
@@ -8,6 +8,32 @@
 
 import Foundation
 
+enum BankConfigurationValidationStatus: Equatable {
+    case valid(selectedBank: ApiBank?)
+    case invalidFilter
+    case invalidPreselectedBank
+    case unknown(error: Error)
+    
+    static func == (lhs: BankConfigurationValidationStatus, rhs: BankConfigurationValidationStatus) -> Bool {
+        switch (lhs, rhs) {
+        case (.valid(let lhsType), .valid(let rhsType)):
+            return lhsType?.id == rhsType?.id
+            
+        case (.invalidFilter, .invalidFilter):
+            return true
+            
+        case (.invalidPreselectedBank, .invalidPreselectedBank):
+            return true
+            
+        case (.unknown(let lhsType), .unknown(let rhsType)):
+            return lhsType.localizedDescription == rhsType.localizedDescription
+            
+        default:
+            return false
+        }
+    }
+}
+
 class ValidateBanksConfigurationUseCase {
     
     enum Status {
@@ -23,7 +49,7 @@ class ValidateBanksConfigurationUseCase {
         preselectedBank: String?,
         bankFilter: [String],
         shouldExcludeBanksWithoutAccountLinkingSupport: Bool,
-        completion: @escaping (Status) -> Void
+        completion: @escaping (BankConfigurationValidationStatus) -> Void
     ) {
         KevinAccountsApiClient.shared.getSupportedBanks(
             token: token,

--- a/Sources/Kevin/InAppPayments/KevinInAppPaymentsPlugin.swift
+++ b/Sources/Kevin/InAppPayments/KevinInAppPaymentsPlugin.swift
@@ -27,7 +27,7 @@ public class KevinInAppPaymentsPlugin: KevinPlugin {
     
     public func getCallbackUrl() throws -> URL {
         guard let configuration = configuration else {
-            throw KevinError(description: "KevinInAppPaymentsPlugin was not configured!")
+            throw KevinErrors.paymentPluginNotConfigured
         }
         return configuration.callbackUrl
     }

--- a/Sources/Kevin/InAppPayments/PaymentConfirmation/KevinPaymentConfirmationViewController.swift
+++ b/Sources/Kevin/InAppPayments/PaymentConfirmation/KevinPaymentConfirmationViewController.swift
@@ -47,7 +47,7 @@ internal class KevinPaymentConfirmationViewController :
                 self.offerIntent(
                     KevinPaymentConfirmationIntent.HandlePaymentCompleted(
                         url: nil,
-                        error: KevinCancelationError(description: "Payment was canceled!")
+                        error: KevinErrors.paymentCanceled
                     )
                 )
             }
@@ -87,7 +87,7 @@ internal class KevinPaymentConfirmationViewController :
         offerIntent(
             KevinPaymentConfirmationIntent.HandlePaymentCompleted(
                 url: nil,
-                error: KevinCancelationError(description: "Payment was canceled!")
+                error: KevinErrors.paymentCanceled
             )
         )
     }

--- a/Sources/Kevin/InAppPayments/PaymentConfirmation/KevinPaymentConfirmationViewModel.swift
+++ b/Sources/Kevin/InAppPayments/PaymentConfirmation/KevinPaymentConfirmationViewModel.swift
@@ -55,7 +55,7 @@ internal class KevinPaymentConfirmationViewModel : KevinViewModel<KevinPaymentCo
                 return
             }
             guard let statusGroup = callbackUrl?["statusGroup"], let status = KevinPaymentStatus(rawValue: statusGroup) else {
-                KevinPaymentSession.shared.notifyPaymentCancelation(error: KevinErrors.unknownPaymetnStatus)
+                KevinPaymentSession.shared.notifyPaymentCancelation(error: KevinErrors.unknownPaymentStatus)
                 return
             }
             if status == .completed || status == .pending {
@@ -66,7 +66,7 @@ internal class KevinPaymentConfirmationViewModel : KevinViewModel<KevinPaymentCo
                     )
                 }
             } else {
-                KevinPaymentSession.shared.notifyPaymentCancelation(error: KevinErrors.unknownPaymetnStatus)
+                KevinPaymentSession.shared.notifyPaymentCancelation(error: KevinErrors.unknownPaymentStatus)
             }
             flowHasBeenProcessed = true
         }

--- a/Sources/Kevin/InAppPayments/PaymentConfirmation/KevinPaymentConfirmationViewModel.swift
+++ b/Sources/Kevin/InAppPayments/PaymentConfirmation/KevinPaymentConfirmationViewModel.swift
@@ -55,7 +55,7 @@ internal class KevinPaymentConfirmationViewModel : KevinViewModel<KevinPaymentCo
                 return
             }
             guard let statusGroup = callbackUrl?["statusGroup"], let status = KevinPaymentStatus(rawValue: statusGroup) else {
-                KevinPaymentSession.shared.notifyPaymentCancelation(error: KevinError(description: "Payment was canceled!"))
+                KevinPaymentSession.shared.notifyPaymentCancelation(error: KevinErrors.unknownPaymetnStatus)
                 return
             }
             if status == .completed || status == .pending {
@@ -66,7 +66,7 @@ internal class KevinPaymentConfirmationViewModel : KevinViewModel<KevinPaymentCo
                     )
                 }
             } else {
-                KevinPaymentSession.shared.notifyPaymentCancelation(error: KevinError(description: "Payment was canceled!"))
+                KevinPaymentSession.shared.notifyPaymentCancelation(error: KevinErrors.unknownPaymetnStatus)
             }
             flowHasBeenProcessed = true
         }

--- a/Sources/Kevin/InAppPayments/PaymentSession/KevinPaymentSession.swift
+++ b/Sources/Kevin/InAppPayments/PaymentSession/KevinPaymentSession.swift
@@ -88,11 +88,11 @@ final public class KevinPaymentSession: NSObject {
             completion(selectedBank)
             
         case .invalidFilter:
-            let error = KevinError(description: "Provided bank filter does not contain supported banks")
+            let error = KevinErrors.filterInvalid
             delegate?.onKevinPaymentCanceled(error: error)
             
         case .invalidPreselectedBank:
-            let error = KevinError(description: "Provided preselected bank is not supported")
+            let error = KevinErrors.preselectedBankNotSupported
             delegate?.onKevinPaymentCanceled(error: error)
             
         case .unknown(let error):

--- a/Sources/Kevin/InAppPayments/PaymentSession/KevinPaymentSession.swift
+++ b/Sources/Kevin/InAppPayments/PaymentSession/KevinPaymentSession.swift
@@ -80,7 +80,7 @@ final public class KevinPaymentSession: NSObject {
     }
 
     private func onBankConfigurationValidation(
-        status: ValidateBanksConfigurationUseCase.Status,
+        status: BankConfigurationValidationStatus,
         completion: @escaping (ApiBank?) -> Void
     ) {
         switch status {

--- a/Sources/Kevin/InAppPayments/PaymentSession/KevinPaymentSessionConfiguration.swift
+++ b/Sources/Kevin/InAppPayments/PaymentSession/KevinPaymentSessionConfiguration.swift
@@ -46,14 +46,14 @@ public class KevinPaymentSessionConfiguration {
         self.confirmInteractiveDismiss = confirmInteractiveDismiss
 
         if skipBankSelection && preselectedBank == nil {
-            throw KevinError(description: "If skipBankSelection is true, preselectedBank must be provided!")
+            throw KevinErrors.preselectedBankNotProvided
         }
         if disableCountrySelection && preselectedCountry == nil {
-            throw KevinError(description: "If disableCountrySelection is true, preselectedCountry must be provided!")
+            throw KevinErrors.preselectedCountryNotProvided
         }
         if let preselectedCountry = preselectedCountry, !countryFilter.isEmpty {
             if !countryFilter.contains(preselectedCountry) {
-                throw KevinError(description: "PreselectedCountry has to be included in countryFilter!")
+                throw KevinErrors.preselectedCountryNoInTheFilter
             }
         }
     }

--- a/Tests/KevinTests/Configuration/LinkingSessionConfigurationTests.swift
+++ b/Tests/KevinTests/Configuration/LinkingSessionConfigurationTests.swift
@@ -1,0 +1,47 @@
+//
+//  LinkingSessionConfigurationTests.swift
+//  kevin.iOS
+//
+//  Created by Daniel Klinge on 08/09/2023.
+//  Copyright © 2023 kevin.. All rights reserved.
+//
+
+import XCTest
+
+@testable import Kevin
+
+@MainActor final class LinkingSessionConfigurationTests: XCTestCase {
+    
+    let authStateMock = "authStateMock"
+    
+    func testAccountLinkingInitiationWithSkippingBankWithoutPreselectingBank() {
+        XCTAssertThrowsError(
+            try KevinAccountLinkingSessionConfiguration.Builder(state: authStateMock)
+                .setSkipBankSelection(true)
+                .build()
+        ) { error in
+            XCTAssertEqual(error as! KevinError, KevinErrors.preselectedBankNotProvided)
+        }
+    }
+
+    func testAccountLinkingInitiationWithDisabledCountrySelectionWithoutPreselectingCountry() {
+        XCTAssertThrowsError(
+            try KevinAccountLinkingSessionConfiguration.Builder(state: authStateMock)
+                .setDisableCountrySelection(true)
+                .build()
+        ) { error in
+            XCTAssertEqual(error as! KevinError, KevinErrors.preselectedCountryNotProvided)
+        }
+    }
+
+    func testAccountLinkingInitiationWithPreselectedCountryThatIsNotPartOfAFilter() {
+        XCTAssertThrowsError(
+            try KevinAccountLinkingSessionConfiguration.Builder(state: authStateMock)
+                .setPreselectedCountry(KevinCountry.austria)
+                .setCountryFilter([KevinCountry.belgium])
+                .build()
+        ) { error in
+            XCTAssertEqual(error as! KevinError, KevinErrors.preselectedCountryNoInTheFilter)
+        }
+    }
+}

--- a/Tests/KevinTests/Configuration/PaymentSessionConfigurationTests.swift
+++ b/Tests/KevinTests/Configuration/PaymentSessionConfigurationTests.swift
@@ -1,0 +1,47 @@
+//
+//  PaymentSessionConfigurationTests.swift
+//  kevin.iOS
+//
+//  Created by Daniel Klinge on 08/09/2023.
+//  Copyright © 2023 kevin.. All rights reserved.
+//
+
+import XCTest
+
+@testable import Kevin
+
+@MainActor final class PaymentSessionConfigurationTests: XCTestCase {
+    
+    let paymentIdMock = "paymentIdMock"
+    
+    func testAccountLinkingInitiationWithSkippingBankWithoutPreselectingBank() {
+        XCTAssertThrowsError(
+            try KevinPaymentSessionConfiguration.Builder(paymentId: paymentIdMock)
+                .setSkipBankSelection(true)
+                .build()
+        ) { error in
+            XCTAssertEqual(error as! KevinError, KevinErrors.preselectedBankNotProvided)
+        }
+    }
+    
+    func testAccountLinkingInitiationWithDisabledCountrySelectionWithoutPreselectingCountry() {
+        XCTAssertThrowsError(
+            try KevinPaymentSessionConfiguration.Builder(paymentId: paymentIdMock)
+                .setDisableCountrySelection(true)
+                .build()
+        ) { error in
+            XCTAssertEqual(error as! KevinError, KevinErrors.preselectedCountryNotProvided)
+        }
+    }
+    
+    func testAccountLinkingInitiationWithPreselectedCountryThatIsNotPartOfAFilter() {
+        XCTAssertThrowsError(
+            try KevinPaymentSessionConfiguration.Builder(paymentId: paymentIdMock)
+                .setPreselectedCountry(KevinCountry.austria)
+                .setCountryFilter([KevinCountry.belgium])
+                .build()
+        ) { error in
+            XCTAssertEqual(error as! KevinError, KevinErrors.preselectedCountryNoInTheFilter)
+        }
+    }
+}

--- a/Tests/KevinTests/KevinTests.swift
+++ b/Tests/KevinTests/KevinTests.swift
@@ -1,5 +1,0 @@
-import XCTest
-
-final class KevinTests: XCTestCase {
-    //  TODO
-}

--- a/Tests/KevinTests/SessionTests/LinkingSessionTests.swift
+++ b/Tests/KevinTests/SessionTests/LinkingSessionTests.swift
@@ -22,6 +22,8 @@ final class LinkingSessionTests: XCTestCase {
     var bank: ApiBank?
     
     override func setUp() {
+        super.setUp()
+        
         KevinApiClient.shared.urlSession = mockURLSession
         
         let configurationAccounts = KevinAccountsConfiguration.Builder(
@@ -36,6 +38,7 @@ final class LinkingSessionTests: XCTestCase {
     }
     
     override func tearDown() {
+        super.tearDown()
         MockURLProtocol.clearHandlers()
     }
 

--- a/Tests/KevinTests/SessionTests/LinkingSessionTests.swift
+++ b/Tests/KevinTests/SessionTests/LinkingSessionTests.swift
@@ -10,7 +10,7 @@ import XCTest
 
 @testable import Kevin
 
-@MainActor final class LinkingSessionTests: XCTestCase {
+final class LinkingSessionTests: XCTestCase {
     
     let authStateMock = "authStateMock"
     let redirectURLMock = "https://redirectURLMock.test/authorization.html"
@@ -21,7 +21,7 @@ import XCTest
     var authorizationCode: String?
     var bank: ApiBank?
     
-    override func setUpWithError() throws {
+    override func setUp() {
         KevinApiClient.shared.urlSession = mockURLSession
         
         let configurationAccounts = KevinAccountsConfiguration.Builder(
@@ -33,13 +33,10 @@ import XCTest
             url: URL.banks(with: authStateMock).absoluteString,
             jsonResponse: banksResponse
         ))
-
-        print("setUpWithError Linking Session Tests")
     }
     
-    override func tearDownWithError() throws {
+    override func tearDown() {
         MockURLProtocol.clearHandlers()
-        print("tearDownWithError Linking Session Tests")
     }
 
     // MARK: - Initiation

--- a/Tests/KevinTests/SessionTests/LinkingSessionTests.swift
+++ b/Tests/KevinTests/SessionTests/LinkingSessionTests.swift
@@ -1,0 +1,267 @@
+//
+//  LinkingSessionTests.swift
+//  kevin.iOS
+//
+//  Created by Daniel Klinge on 05/09/2023.
+//  Copyright © 2023 kevin.. All rights reserved.
+//
+
+import XCTest
+
+@testable import Kevin
+
+@MainActor final class LinkingSessionTests: XCTestCase {
+    
+    let authStateMock = "authStateMock"
+    let redirectURLMock = "https://redirectURLMock.test/authorization.html"
+    
+    var expectation: XCTestExpectation?
+    var controller: UINavigationController?
+    var error: Error?
+    var authorizationCode: String?
+    var bank: ApiBank?
+    
+    override func setUpWithError() throws {
+        KevinApiClient.shared.urlSession = mockURLSession
+        
+        let configurationAccounts = KevinAccountsConfiguration.Builder(
+            callbackUrl: URL(string: redirectURLMock)!
+        ).build()
+        KevinAccountsPlugin.shared.configure(configurationAccounts)
+
+        MockURLProtocol.add(handler: MockRequestHandler(
+            url: URL.banks(with: authStateMock).absoluteString,
+            jsonResponse: banksResponse
+        ))
+
+        print("setUpWithError Linking Session Tests")
+    }
+    
+    override func tearDownWithError() throws {
+        MockURLProtocol.clearHandlers()
+        print("tearDownWithError Linking Session Tests")
+    }
+
+    // MARK: - Initiation
+    
+    func testAccountLinkingInitiationWithBankSelectionView() throws {
+        // 1. Assign
+        KevinAccountLinkingSession.shared.delegate = self
+        let configuration = try KevinAccountLinkingSessionConfiguration.Builder(state: authStateMock)
+            .build()
+
+        // 2. Act
+        expectation = expectation(description: "Account linking initiates")
+        KevinAccountLinkingSession.shared.initiateAccountLinking(configuration: configuration)
+
+        waitForExpectations(timeout: 0.1)
+
+        // 3. Assert
+        let resultVC = try XCTUnwrap(controller)
+        let resultBankSelectionViewController = resultVC.topViewController as? KevinBankSelectionViewController
+        
+        XCTAssertNotNil(resultBankSelectionViewController)
+        XCTAssertNil(resultBankSelectionViewController?.configuration.selectedBankId)
+    }
+    
+    func testAccountLinkingInitiationWithBankSelectionViewWithPreselectedBank() throws {
+        // 1. Assign
+        let preselectedBankId = "INDUSTRA_LT"
+        KevinAccountLinkingSession.shared.delegate = self
+        let configuration = try KevinAccountLinkingSessionConfiguration.Builder(state: authStateMock)
+            .setPreselectedBank(preselectedBankId)
+            .build()
+
+        // 2. Act
+        expectation = expectation(description: "Account linking initiates")
+        KevinAccountLinkingSession.shared.initiateAccountLinking(configuration: configuration)
+
+        waitForExpectations(timeout: 0.1)
+
+        // 3. Assert
+        let resultVC = try XCTUnwrap(controller)
+        let resultBankSelectionViewController = resultVC.topViewController as? KevinBankSelectionViewController
+        
+        XCTAssertNotNil(resultBankSelectionViewController)
+        XCTAssertEqual(resultBankSelectionViewController?.configuration.selectedBankId, preselectedBankId)
+    }
+    
+
+    func testAccountLinkingInitiationWithAccountLinkingConfirmationView() throws {
+        // 1. Assign
+        KevinAccountLinkingSession.shared.delegate = self
+        let configuration = try KevinAccountLinkingSessionConfiguration.Builder(state: authStateMock)
+            .setPreselectedBank("INDUSTRA_LT")
+            .setSkipBankSelection(true)
+            .build()
+
+        // 2. Act
+        expectation = expectation(description: "Account linking initiates")
+        KevinAccountLinkingSession.shared.initiateAccountLinking(configuration: configuration)
+
+        waitForExpectations(timeout: 0.1)
+
+        // 3. Assert
+        let resultVC = try XCTUnwrap(controller)
+        XCTAssert(resultVC.topViewController is KevinAccountLinkingViewController)
+    }
+    
+    func testAccountLinkingInitiationWithErrorPreselectedBankIncorrect() throws {
+        // 1. Assign
+        KevinAccountLinkingSession.shared.delegate = self
+        let configuration = try KevinAccountLinkingSessionConfiguration.Builder(state: authStateMock)
+            .setPreselectedBank("UNAVAILABLE_BANK")
+            .build()
+
+        // 2. Act
+        expectation = expectation(description: "Account linking initiates")
+        KevinAccountLinkingSession.shared.initiateAccountLinking(configuration: configuration)
+
+        waitForExpectations(timeout: 0.1)
+
+        // 3. Assert
+        let resultError = try XCTUnwrap(error)
+        XCTAssertEqual(resultError.localizedDescription, "Provided preselected bank is not supported")
+    }
+    
+    func testAccountLinkingInitiationWithErrorBankFilterIncorrect() throws {
+        // 1. Assign
+        KevinAccountLinkingSession.shared.delegate = self
+        let configuration = try KevinAccountLinkingSessionConfiguration.Builder(state: authStateMock)
+            .setBankFilter(["UNAVAILABLE_BANK"])
+            .build()
+
+        // 2. Act
+        expectation = expectation(description: "Account linking initiates")
+        KevinAccountLinkingSession.shared.initiateAccountLinking(configuration: configuration)
+
+        waitForExpectations(timeout: 0.1)
+
+        // 3. Assert
+        let resultError = try XCTUnwrap(error)
+        XCTAssertEqual(resultError.localizedDescription, "Provided bank filter does not contain supported banks")
+    }
+    
+    func testAccountLinkingInitiationWithNetworkError() throws {
+        // 1. Assign
+        KevinAccountLinkingSession.shared.delegate = self
+        let configuration = try KevinAccountLinkingSessionConfiguration.Builder(state: authStateMock)
+            .build()
+
+        MockURLProtocol.clearHandlers()
+        MockURLProtocol.add(handler: MockRequestHandler(
+            url: URL.banks(with: authStateMock).absoluteString,
+            statusCode: 404
+        ))
+
+        // 2. Act
+        expectation = expectation(description: "Account linking initiates")
+        KevinAccountLinkingSession.shared.initiateAccountLinking(configuration: configuration)
+
+        waitForExpectations(timeout: 0.1)
+
+        // 3. Assert
+        let resultError = try XCTUnwrap(error)
+        let resultApiError = resultError as? KevinApiError
+
+        XCTAssertNotNil(resultApiError)
+    }
+    
+    // MARK: - Cancelation
+    
+    func testLinkingCancelationOnBankSelectionView() throws {
+        // 1. Assign
+        KevinAccountLinkingSession.shared.delegate = self
+        let configuration = try KevinAccountLinkingSessionConfiguration.Builder(state: authStateMock)
+            .build()
+
+        // 2. Act
+        expectation = expectation(description: "Account linking initiates")
+        KevinAccountLinkingSession.shared.initiateAccountLinking(configuration: configuration)
+        
+        waitForExpectations(timeout: 0.1)
+        
+        let resultVC = try XCTUnwrap(controller)
+        let resultBankSelectionViewController = resultVC.topViewController as? KevinBankSelectionViewController
+        
+        expectation = expectation(description: "Account linking cancelled")
+        resultBankSelectionViewController?.onExit?()
+        
+        waitForExpectations(timeout: 0.1)
+
+        // 3. Assert
+        let resultError = try XCTUnwrap(error)
+        let resultCancelationError = resultError as? KevinCancelationError
+
+        XCTAssertNotNil(resultCancelationError)
+    }
+    
+    func testLinkingCancelationOnAccountLinkingConfirmationView() throws {
+        // 1. Assign
+        KevinAccountLinkingSession.shared.delegate = self
+        let configuration = try KevinAccountLinkingSessionConfiguration.Builder(state: authStateMock)
+            .setPreselectedBank("INDUSTRA_LT")
+            .setSkipBankSelection(true)
+            .build()
+
+        // 2. Act
+        expectation = expectation(description: "Account linking initiates")
+        KevinAccountLinkingSession.shared.initiateAccountLinking(configuration: configuration)
+        
+        waitForExpectations(timeout: 0.1)
+        
+        let resultVC = try XCTUnwrap(controller)
+        let resultAccountLinkingViewController = resultVC.topViewController as? KevinAccountLinkingViewController
+        
+        expectation = expectation(description: "Account linking cancelled")
+        resultAccountLinkingViewController?.onClose?()
+        
+        waitForExpectations(timeout: 0.1)
+
+        // 3. Assert
+        let resultError = try XCTUnwrap(error)
+        let resultCancelationError = resultError as? KevinCancelationError
+
+        XCTAssertNotNil(resultCancelationError)
+    }
+}
+
+extension LinkingSessionTests: KevinAccountLinkingSessionDelegate {
+
+    func onKevinAccountLinkingStarted(controller: UINavigationController) {
+        self.controller = controller
+        expectation?.fulfill()
+        expectation = nil
+    }
+
+    func onKevinAccountLinkingCanceled(error: Error?) {
+        self.error = error
+        expectation?.fulfill()
+        expectation = nil
+    }
+
+    func onKevinAccountLinkingSucceeded(authorizationCode: String, bank: ApiBank?, linkingType: KevinAccountLinkingType) {
+        self.authorizationCode = authorizationCode
+        self.bank = bank
+        expectation?.fulfill()
+        expectation = nil
+    }
+}
+
+private let banksResponse = """
+{
+  "data": [
+    {
+      "id": "INDUSTRA_LT",
+      "name": "Industra",
+      "officialName": "AS Industra Bank Lietuvos filialas",
+      "countryCode": "LT",
+      "isSandbox": false,
+      "imageUri": "https://cdn.kevin.eu/banks/images/INDUSTRA_LT.png",
+      "bic": "MULTLT2X",
+      "isBeta": false,
+      "isAccountLinkingSupported": true
+    }
+  ]
+}
+"""

--- a/Tests/KevinTests/SessionTests/LinkingSessionTests.swift
+++ b/Tests/KevinTests/SessionTests/LinkingSessionTests.swift
@@ -30,6 +30,7 @@ final class LinkingSessionTests: XCTestCase {
             callbackUrl: URL(string: redirectURLMock)!
         ).build()
         KevinAccountsPlugin.shared.configure(configurationAccounts)
+        KevinAccountLinkingSession.shared.delegate = self
 
         MockURLProtocol.add(handler: MockRequestHandler(
             url: URL.banks(with: authStateMock).absoluteString,
@@ -46,7 +47,6 @@ final class LinkingSessionTests: XCTestCase {
     
     func testAccountLinkingInitiationWithBankSelectionView() throws {
         // 1. Assign
-        KevinAccountLinkingSession.shared.delegate = self
         let configuration = try KevinAccountLinkingSessionConfiguration.Builder(state: authStateMock)
             .build()
 
@@ -67,7 +67,6 @@ final class LinkingSessionTests: XCTestCase {
     func testAccountLinkingInitiationWithBankSelectionViewWithPreselectedBank() throws {
         // 1. Assign
         let preselectedBankId = "INDUSTRA_LT"
-        KevinAccountLinkingSession.shared.delegate = self
         let configuration = try KevinAccountLinkingSessionConfiguration.Builder(state: authStateMock)
             .setPreselectedBank(preselectedBankId)
             .build()
@@ -89,7 +88,6 @@ final class LinkingSessionTests: XCTestCase {
 
     func testAccountLinkingInitiationWithAccountLinkingConfirmationView() throws {
         // 1. Assign
-        KevinAccountLinkingSession.shared.delegate = self
         let configuration = try KevinAccountLinkingSessionConfiguration.Builder(state: authStateMock)
             .setPreselectedBank("INDUSTRA_LT")
             .setSkipBankSelection(true)
@@ -108,7 +106,6 @@ final class LinkingSessionTests: XCTestCase {
     
     func testAccountLinkingInitiationWithErrorPreselectedBankIncorrect() throws {
         // 1. Assign
-        KevinAccountLinkingSession.shared.delegate = self
         let configuration = try KevinAccountLinkingSessionConfiguration.Builder(state: authStateMock)
             .setPreselectedBank("UNAVAILABLE_BANK")
             .build()
@@ -126,7 +123,6 @@ final class LinkingSessionTests: XCTestCase {
     
     func testAccountLinkingInitiationWithErrorBankFilterIncorrect() throws {
         // 1. Assign
-        KevinAccountLinkingSession.shared.delegate = self
         let configuration = try KevinAccountLinkingSessionConfiguration.Builder(state: authStateMock)
             .setBankFilter(["UNAVAILABLE_BANK"])
             .build()
@@ -144,7 +140,6 @@ final class LinkingSessionTests: XCTestCase {
     
     func testAccountLinkingInitiationWithNetworkError() throws {
         // 1. Assign
-        KevinAccountLinkingSession.shared.delegate = self
         let configuration = try KevinAccountLinkingSessionConfiguration.Builder(state: authStateMock)
             .build()
 
@@ -171,7 +166,6 @@ final class LinkingSessionTests: XCTestCase {
     
     func testLinkingCancelationOnBankSelectionView() throws {
         // 1. Assign
-        KevinAccountLinkingSession.shared.delegate = self
         let configuration = try KevinAccountLinkingSessionConfiguration.Builder(state: authStateMock)
             .build()
 
@@ -198,7 +192,6 @@ final class LinkingSessionTests: XCTestCase {
     
     func testLinkingCancelationOnAccountLinkingConfirmationView() throws {
         // 1. Assign
-        KevinAccountLinkingSession.shared.delegate = self
         let configuration = try KevinAccountLinkingSessionConfiguration.Builder(state: authStateMock)
             .setPreselectedBank("INDUSTRA_LT")
             .setSkipBankSelection(true)
@@ -231,7 +224,6 @@ final class LinkingSessionTests: XCTestCase {
         // 1. Assign
         let bankId = "INDUSTRA_LT"
         
-        KevinAccountLinkingSession.shared.delegate = self
         let configuration = try KevinAccountLinkingSessionConfiguration.Builder(state: authStateMock)
             .build()
 
@@ -263,7 +255,6 @@ final class LinkingSessionTests: XCTestCase {
         // 1. Assign
         let bankId = "UNAVAILABLE_BANK"
         
-        KevinAccountLinkingSession.shared.delegate = self
         let configuration = try KevinAccountLinkingSessionConfiguration.Builder(state: authStateMock)
             .build()
 
@@ -293,7 +284,6 @@ final class LinkingSessionTests: XCTestCase {
         let bankId = "INDUSTRA_LT"
         let country = KevinCountry.austria
         
-        KevinAccountLinkingSession.shared.delegate = self
         let configuration = try KevinAccountLinkingSessionConfiguration.Builder(state: authStateMock)
             .build()
         

--- a/Tests/KevinTests/SessionTests/PaymentSessionTests.swift
+++ b/Tests/KevinTests/SessionTests/PaymentSessionTests.swift
@@ -30,6 +30,7 @@ final class PaymentSessionTests: XCTestCase {
             callbackUrl: URL(string: redirectURLMock)!
         ).build()
         KevinInAppPaymentsPlugin.shared.configure(configurationPayments)
+        KevinPaymentSession.shared.delegate = self
 
         MockURLProtocol.add(handler: MockRequestHandler(
             url: URL.banks(with: paymentIdMock).absoluteString,
@@ -46,7 +47,6 @@ final class PaymentSessionTests: XCTestCase {
     
     func testPaymentInitiationWithBankSelectionView() throws {
         // 1. Assign
-        KevinPaymentSession.shared.delegate = self
         let configuration = try KevinPaymentSessionConfiguration.Builder(paymentId: paymentIdMock)
             .build()
 
@@ -67,7 +67,6 @@ final class PaymentSessionTests: XCTestCase {
     func testPaymentInitiationWithBankSelectionViewWithPreselectedBank() throws {
         // 1. Assign
         let preselectedBankId = "INDUSTRA_LT"
-        KevinPaymentSession.shared.delegate = self
         let configuration = try KevinPaymentSessionConfiguration.Builder(paymentId: paymentIdMock)
             .setPreselectedBank(preselectedBankId)
             .build()
@@ -89,7 +88,6 @@ final class PaymentSessionTests: XCTestCase {
 
     func testPaymentInitiationWithAccountLinkingConfirmationView() throws {
         // 1. Assign
-        KevinPaymentSession.shared.delegate = self
         let configuration = try KevinPaymentSessionConfiguration.Builder(paymentId: paymentIdMock)
             .setPreselectedBank("INDUSTRA_LT")
             .setSkipBankSelection(true)
@@ -108,7 +106,6 @@ final class PaymentSessionTests: XCTestCase {
 
     func testPaymentInitiationWithErrorPreselectedBankIncorrect() throws {
         // 1. Assign
-        KevinPaymentSession.shared.delegate = self
         let configuration = try KevinPaymentSessionConfiguration.Builder(paymentId: paymentIdMock)
             .setPreselectedBank("UNAVAILABLE_BANK")
             .build()
@@ -126,7 +123,6 @@ final class PaymentSessionTests: XCTestCase {
 
     func testPaymentInitiationWithErrorBankFilterIncorrect() throws {
         // 1. Assign
-        KevinPaymentSession.shared.delegate = self
         let configuration = try KevinPaymentSessionConfiguration.Builder(paymentId: paymentIdMock)
             .setBankFilter(["UNAVAILABLE_BANK"])
             .build()
@@ -144,7 +140,6 @@ final class PaymentSessionTests: XCTestCase {
 
     func testPaymentInitiationWithNetworkError() throws {
         // 1. Assign
-        KevinPaymentSession.shared.delegate = self
         let configuration = try KevinPaymentSessionConfiguration.Builder(paymentId: paymentIdMock)
             .build()
 
@@ -171,7 +166,6 @@ final class PaymentSessionTests: XCTestCase {
 
     func testPaymentCancelationOnBankSelectionView() throws {
         // 1. Assign
-        KevinPaymentSession.shared.delegate = self
         let configuration = try KevinPaymentSessionConfiguration.Builder(paymentId: paymentIdMock)
             .build()
 
@@ -202,7 +196,6 @@ final class PaymentSessionTests: XCTestCase {
         // 1. Assign
         let status = KevinPaymentStatus.completed
 
-        KevinPaymentSession.shared.delegate = self
         let configuration = try KevinPaymentSessionConfiguration.Builder(paymentId: paymentIdMock)
             .build()
 
@@ -232,7 +225,6 @@ final class PaymentSessionTests: XCTestCase {
         // 1. Assign
         let status = KevinPaymentStatus.pending
 
-        KevinPaymentSession.shared.delegate = self
         let configuration = try KevinPaymentSessionConfiguration.Builder(paymentId: paymentIdMock)
             .build()
 
@@ -262,7 +254,6 @@ final class PaymentSessionTests: XCTestCase {
         // 1. Assign
         let status = KevinPaymentStatus.unknown
 
-        KevinPaymentSession.shared.delegate = self
         let configuration = try KevinPaymentSessionConfiguration.Builder(paymentId: paymentIdMock)
             .build()
 

--- a/Tests/KevinTests/SessionTests/PaymentSessionTests.swift
+++ b/Tests/KevinTests/SessionTests/PaymentSessionTests.swift
@@ -1,0 +1,326 @@
+//
+//  PaymentSessionTests.swift
+//  kevin.iOS
+//
+//  Created by Daniel Klinge on 05/09/2023.
+//  Copyright © 2023 kevin.. All rights reserved.
+//
+
+import XCTest
+
+@testable import Kevin
+
+final class PaymentSessionTests: XCTestCase {
+    
+    let paymentIdMock = "paymentIdMock"
+    let redirectURLMock = "https://redirectURLMock.test/authorization.html"
+    
+    var expectation: XCTestExpectation?
+    var controller: UINavigationController?
+    var error: Error?
+    var paymentId: String?
+    var status: KevinPaymentStatus?
+    
+    override func setUp() {
+        KevinApiClient.shared.urlSession = mockURLSession
+        
+        let configurationPayments = KevinInAppPaymentsConfiguration.Builder(
+            callbackUrl: URL(string: redirectURLMock)!
+        ).build()
+        KevinInAppPaymentsPlugin.shared.configure(configurationPayments)
+
+        MockURLProtocol.add(handler: MockRequestHandler(
+            url: URL.banks(with: paymentIdMock).absoluteString,
+            jsonResponse: banksResponse
+        ))
+    }
+    
+    override func tearDown() {
+        MockURLProtocol.clearHandlers()
+    }
+
+    // MARK: - Initiation
+    
+    func testPaymentInitiationWithBankSelectionView() throws {
+        // 1. Assign
+        KevinPaymentSession.shared.delegate = self
+        let configuration = try KevinPaymentSessionConfiguration.Builder(paymentId: paymentIdMock)
+            .build()
+
+        // 2. Act
+        expectation = expectation(description: "Payment initiates")
+        KevinPaymentSession.shared.initiatePayment(configuration: configuration)
+
+        waitForExpectations(timeout: 0.1)
+
+        // 3. Assert
+        let resultVC = try XCTUnwrap(controller)
+        let resultBankSelectionViewController = resultVC.topViewController as? KevinBankSelectionViewController
+
+        XCTAssertNotNil(resultBankSelectionViewController)
+        XCTAssertNil(resultBankSelectionViewController?.configuration.selectedBankId)
+    }
+
+    func testPaymentInitiationWithBankSelectionViewWithPreselectedBank() throws {
+        // 1. Assign
+        let preselectedBankId = "INDUSTRA_LT"
+        KevinPaymentSession.shared.delegate = self
+        let configuration = try KevinPaymentSessionConfiguration.Builder(paymentId: paymentIdMock)
+            .setPreselectedBank(preselectedBankId)
+            .build()
+
+        // 2. Act
+        expectation = expectation(description: "Payment initiates")
+        KevinPaymentSession.shared.initiatePayment(configuration: configuration)
+
+        waitForExpectations(timeout: 0.1)
+
+        // 3. Assert
+        let resultVC = try XCTUnwrap(controller)
+        let resultBankSelectionViewController = resultVC.topViewController as? KevinBankSelectionViewController
+
+        XCTAssertNotNil(resultBankSelectionViewController)
+        XCTAssertEqual(resultBankSelectionViewController?.configuration.selectedBankId, preselectedBankId)
+    }
+
+
+    func testPaymentInitiationWithAccountLinkingConfirmationView() throws {
+        // 1. Assign
+        KevinPaymentSession.shared.delegate = self
+        let configuration = try KevinPaymentSessionConfiguration.Builder(paymentId: paymentIdMock)
+            .setPreselectedBank("INDUSTRA_LT")
+            .setSkipBankSelection(true)
+            .build()
+
+        // 2. Act
+        expectation = expectation(description: "Payment initiates")
+        KevinPaymentSession.shared.initiatePayment(configuration: configuration)
+
+        waitForExpectations(timeout: 0.1)
+
+        // 3. Assert
+        let resultVC = try XCTUnwrap(controller)
+        XCTAssert(resultVC.topViewController is KevinPaymentConfirmationViewController)
+    }
+
+    func testPaymentInitiationWithErrorPreselectedBankIncorrect() throws {
+        // 1. Assign
+        KevinPaymentSession.shared.delegate = self
+        let configuration = try KevinPaymentSessionConfiguration.Builder(paymentId: paymentIdMock)
+            .setPreselectedBank("UNAVAILABLE_BANK")
+            .build()
+
+        // 2. Act
+        expectation = expectation(description: "Payment initiates")
+        KevinPaymentSession.shared.initiatePayment(configuration: configuration)
+
+        waitForExpectations(timeout: 0.1)
+
+        // 3. Assert
+        let resultError = try XCTUnwrap(error) as? KevinError
+        XCTAssertEqual(resultError, KevinErrors.preselectedBankNotSupported)
+    }
+
+    func testPaymentInitiationWithErrorBankFilterIncorrect() throws {
+        // 1. Assign
+        KevinPaymentSession.shared.delegate = self
+        let configuration = try KevinPaymentSessionConfiguration.Builder(paymentId: paymentIdMock)
+            .setBankFilter(["UNAVAILABLE_BANK"])
+            .build()
+
+        // 2. Act
+        expectation = expectation(description: "Payment initiates")
+        KevinPaymentSession.shared.initiatePayment(configuration: configuration)
+
+        waitForExpectations(timeout: 0.1)
+
+        // 3. Assert
+        let resultError = try XCTUnwrap(error) as? KevinError
+        XCTAssertEqual(resultError, KevinErrors.filterInvalid)
+    }
+
+    func testPaymentInitiationWithNetworkError() throws {
+        // 1. Assign
+        KevinPaymentSession.shared.delegate = self
+        let configuration = try KevinPaymentSessionConfiguration.Builder(paymentId: paymentIdMock)
+            .build()
+
+        MockURLProtocol.clearHandlers()
+        MockURLProtocol.add(handler: MockRequestHandler(
+            url: URL.banks(with: paymentIdMock).absoluteString,
+            statusCode: 404
+        ))
+
+        // 2. Act
+        expectation = expectation(description: "Payment initiates")
+        KevinPaymentSession.shared.initiatePayment(configuration: configuration)
+
+        waitForExpectations(timeout: 0.1)
+
+        // 3. Assert
+        let resultError = try XCTUnwrap(error)
+        let resultApiError = resultError as? KevinApiError
+
+        XCTAssertNotNil(resultApiError)
+    }
+
+    // MARK: - Cancelation
+
+    func testPaymentCancelationOnBankSelectionView() throws {
+        // 1. Assign
+        KevinPaymentSession.shared.delegate = self
+        let configuration = try KevinPaymentSessionConfiguration.Builder(paymentId: paymentIdMock)
+            .build()
+
+        // 2. Act
+        expectation = expectation(description: "Payment initiates")
+        KevinPaymentSession.shared.initiatePayment(configuration: configuration)
+
+        waitForExpectations(timeout: 0.1)
+
+        let resultVC = try XCTUnwrap(controller)
+        let resultBankSelectionViewController = resultVC.topViewController as? KevinBankSelectionViewController
+
+        expectation = expectation(description: "Payment cancelled")
+        resultBankSelectionViewController?.onExit?()
+
+        waitForExpectations(timeout: 0.1)
+
+        // 3. Assert
+        let resultError = try XCTUnwrap(error)
+        let resultCancelationError = resultError as? KevinCancelationError
+
+        XCTAssertNotNil(resultCancelationError)
+    }
+
+    // MARK: - Linking completion
+
+    func testPaymentCompletion() throws {
+        // 1. Assign
+        let status = KevinPaymentStatus.completed
+
+        KevinPaymentSession.shared.delegate = self
+        let configuration = try KevinPaymentSessionConfiguration.Builder(paymentId: paymentIdMock)
+            .build()
+
+        // 2. Act
+        expectation = expectation(description: "Payment initiates")
+        KevinPaymentSession.shared.initiatePayment(configuration: configuration)
+
+        waitForExpectations(timeout: 0.1)
+
+        expectation = expectation(description: "Payment completed")
+        KevinPaymentSession.shared.notifyPaymentCompletion(
+            paymentId: paymentIdMock,
+            status: status
+        )
+
+        waitForExpectations(timeout: 0.1)
+
+        // 3. Assert
+        let resultPaymentId = try XCTUnwrap(paymentId)
+        let resultStatus = try XCTUnwrap(status)
+
+        XCTAssertEqual(resultPaymentId, paymentIdMock)
+        XCTAssertEqual(resultStatus, status)
+    }
+
+    func testPaymentPending() throws {
+        // 1. Assign
+        let status = KevinPaymentStatus.pending
+
+        KevinPaymentSession.shared.delegate = self
+        let configuration = try KevinPaymentSessionConfiguration.Builder(paymentId: paymentIdMock)
+            .build()
+
+        // 2. Act
+        expectation = expectation(description: "Payment initiates")
+        KevinPaymentSession.shared.initiatePayment(configuration: configuration)
+
+        waitForExpectations(timeout: 0.1)
+
+        expectation = expectation(description: "Payment completed")
+        KevinPaymentSession.shared.notifyPaymentCompletion(
+            paymentId: paymentIdMock,
+            status: status
+        )
+
+        waitForExpectations(timeout: 0.1)
+
+        // 3. Assert
+        let resultPaymentId = try XCTUnwrap(paymentId)
+        let resultStatus = try XCTUnwrap(status)
+
+        XCTAssertEqual(resultPaymentId, paymentIdMock)
+        XCTAssertEqual(resultStatus, status)
+    }
+    
+    func testPaymentUnknown() throws {
+        // 1. Assign
+        let status = KevinPaymentStatus.unknown
+
+        KevinPaymentSession.shared.delegate = self
+        let configuration = try KevinPaymentSessionConfiguration.Builder(paymentId: paymentIdMock)
+            .build()
+
+        // 2. Act
+        expectation = expectation(description: "Payment initiates")
+        KevinPaymentSession.shared.initiatePayment(configuration: configuration)
+
+        waitForExpectations(timeout: 0.1)
+
+        expectation = expectation(description: "Payment completed")
+        KevinPaymentSession.shared.notifyPaymentCompletion(
+            paymentId: paymentIdMock,
+            status: status
+        )
+
+        waitForExpectations(timeout: 0.1)
+
+        // 3. Assert
+        let resultPaymentId = try XCTUnwrap(paymentId)
+        let resultStatus = try XCTUnwrap(status)
+
+        XCTAssertEqual(resultPaymentId, paymentIdMock)
+        XCTAssertEqual(resultStatus, status)
+    }
+}
+
+extension PaymentSessionTests: KevinPaymentSessionDelegate {
+    func onKevinPaymentInitiationStarted(controller: UINavigationController) {
+        self.controller = controller
+        expectation?.fulfill()
+        expectation = nil
+    }
+    
+    func onKevinPaymentCanceled(error: Error?) {
+        self.error = error
+        expectation?.fulfill()
+        expectation = nil
+    }
+    
+    func onKevinPaymentSucceeded(paymentId: String, status: KevinPaymentStatus) {
+        self.paymentId = paymentId
+        self.status = status
+        expectation?.fulfill()
+        expectation = nil
+    }
+}
+
+private let banksResponse = """
+{
+  "data": [
+    {
+      "id": "INDUSTRA_LT",
+      "name": "Industra",
+      "officialName": "AS Industra Bank Lietuvos filialas",
+      "countryCode": "LT",
+      "isSandbox": false,
+      "imageUri": "https://cdn.kevin.eu/banks/images/INDUSTRA_LT.png",
+      "bic": "MULTLT2X",
+      "isBeta": false,
+      "isAccountLinkingSupported": true
+    }
+  ]
+}
+"""

--- a/Tests/KevinTests/SessionTests/PaymentSessionTests.swift
+++ b/Tests/KevinTests/SessionTests/PaymentSessionTests.swift
@@ -22,6 +22,8 @@ final class PaymentSessionTests: XCTestCase {
     var status: KevinPaymentStatus?
     
     override func setUp() {
+        super.setUp()
+        
         KevinApiClient.shared.urlSession = mockURLSession
         
         let configurationPayments = KevinInAppPaymentsConfiguration.Builder(
@@ -36,6 +38,7 @@ final class PaymentSessionTests: XCTestCase {
     }
     
     override func tearDown() {
+        super.tearDown()
         MockURLProtocol.clearHandlers()
     }
 

--- a/Tests/KevinTests/Utils/MockURLProtocol.swift
+++ b/Tests/KevinTests/Utils/MockURLProtocol.swift
@@ -1,0 +1,78 @@
+//
+//  MockURLProtocol.swift
+//  kevin.iOS
+//
+//  Created by Daniel Klinge on 07/09/2023.
+//  Copyright © 2023 kevin.. All rights reserved.
+//
+
+import Foundation
+
+var mockURLSession: URLSession {
+    let configuration: URLSessionConfiguration = .ephemeral
+    configuration.protocolClasses = [MockURLProtocol.self]
+    return URLSession(configuration: configuration)
+}
+
+struct MockRequestHandler {
+    let url: String
+    var statusCode: Int = 200
+    var jsonResponse: String?
+    var customHandler: (() -> Void)?
+}
+
+class MockURLProtocol: URLProtocol {
+    private static var error: Error?
+    private static var requestHandlers: [MockRequestHandler] = []
+
+    static func add(handler: MockRequestHandler) {
+        requestHandlers.append(handler)
+    }
+
+    static func clearHandlers() {
+        requestHandlers.removeAll()
+    }
+
+    override class func canInit(with request: URLRequest) -> Bool {
+        return true
+    }
+
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest {
+        return request
+    }
+
+    override func startLoading() {
+        if let error = MockURLProtocol.error {
+            client?.urlProtocol(self, didFailWithError: error)
+            return
+        }
+
+        let handler = Self.requestHandlers.first {
+            $0.url == request.url?.absoluteString
+        }
+        guard let handler else {
+            assertionFailure(
+                "Missing requestHandler for \(String(describing: request.url?.absoluteString))" +
+                "Configured handlers are: \n \(Self.requestHandlers.map { $0.url }.joined(separator: " \n"))"
+            )
+            return
+        }
+
+        let response = HTTPURLResponse(
+            url: URL(string: handler.url)!,
+            statusCode: handler.statusCode,
+            httpVersion: nil,
+            headerFields: ["Content-Type": "application/json"]
+        )!
+
+        client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+        if let response = handler.jsonResponse {
+            client?.urlProtocol(self, didLoad: response.data(using: .utf8)!)
+        }
+        client?.urlProtocolDidFinishLoading(self)
+    }
+
+    override func stopLoading() {
+
+    }
+}

--- a/Tests/KevinTests/Utils/MockURLProtocol.swift
+++ b/Tests/KevinTests/Utils/MockURLProtocol.swift
@@ -69,6 +69,9 @@ class MockURLProtocol: URLProtocol {
         if let response = handler.jsonResponse {
             client?.urlProtocol(self, didLoad: response.data(using: .utf8)!)
         }
+        if let customHandler = handler.customHandler {
+            customHandler()
+        }
         client?.urlProtocolDidFinishLoading(self)
     }
 

--- a/Tests/KevinTests/ViewModels/KevinAccountLinkingViewModelTests.swift
+++ b/Tests/KevinTests/ViewModels/KevinAccountLinkingViewModelTests.swift
@@ -1,0 +1,328 @@
+//
+//  KevinAccountLinkingViewModelTests.swift
+//  kevin.iOS
+//
+//  Created by Daniel Klinge on 11/09/2023.
+//  Copyright © 2023 kevin.. All rights reserved.
+//
+
+import XCTest
+
+@testable import Kevin
+
+final class KevinAccountLinkingViewModelTests: XCTestCase {
+    
+    let authStateMock = "authStateMock"
+    let redirectURLMock = "https://redirectURLMock.test/authorization.html"
+    
+    var viewModel: KevinAccountLinkingViewModel!
+    var state: KevinAccountLinkingState?
+    
+    var expectation: XCTestExpectation?
+    var controller: UINavigationController?
+    var error: Error?
+    var authorizationCode: String?
+    var bank: ApiBank?
+    
+    override func setUp() {
+        super.setUp()
+
+        // MARK: Set up networking mock
+        KevinApiClient.shared.urlSession = mockURLSession
+        MockURLProtocol.add(handler: MockRequestHandler(
+            url: URL.banks(with: authStateMock).absoluteString,
+            jsonResponse: banksResponse
+        ))
+        MockURLProtocol.add(handler: MockRequestHandler(
+            url: URL.banks(with: authStateMock).absoluteString + "?countryCode=lt",
+            jsonResponse: banksResponse
+        ))
+        
+        // MARK: Set up SDK
+        let configurationAccounts = KevinAccountsConfiguration.Builder(
+            callbackUrl: URL(string: redirectURLMock)!
+        ).build()
+        KevinAccountsPlugin.shared.configure(configurationAccounts)
+        
+        // MARK: Set up view model
+        viewModel = KevinAccountLinkingViewModel()
+        viewModel.onStateChanged = { [weak self] state in
+            self?.state = state
+        }
+    }
+    
+    override func tearDown() {
+        super.tearDown()
+        MockURLProtocol.clearHandlers()
+    }
+    
+    func testViewModelInitiation() {
+        // 1. Assign
+        let selectedBankId = "INDUSTRA_LT"
+        let selectedCoutnry = KevinCountry.lithuania
+        
+        let configuration = KevinAccountLinkingConfiguration(
+            state: authStateMock,
+            selectedBankId: selectedBankId,
+            selectedCountry: selectedCoutnry,
+            linkingType: .bank
+        )
+        let intent = KevinAccountLinkingIntent.Initialize(configuration: configuration)
+        
+        let expectedBaseUrl = String(format: KevinApiPaths.bankLinkingUrl, authStateMock, selectedBankId)
+        
+        // 2. Act
+        viewModel.offer(intent: intent)
+        
+        // 3. Assert
+        XCTAssertEqual(state?.accountLinkingType, .bank)
+        XCTAssertEqual(state?.bankRedirectUrl.absoluteString.contains(expectedBaseUrl), true)
+    }
+    
+    func testViewModelLinkingCompletion() throws {
+        // 1. Assign
+        KevinAccountLinkingSession.shared.delegate = self
+        let sdkConfiguration = try KevinAccountLinkingSessionConfiguration.Builder(state: authStateMock)
+            .build()
+                
+        let selectedBankId = "INDUSTRA_LT"
+        let selectedCoutnry = KevinCountry.lithuania
+
+        let configuration = KevinAccountLinkingConfiguration(
+            state: authStateMock,
+            selectedBankId: selectedBankId,
+            selectedCountry: selectedCoutnry,
+            linkingType: .bank
+        )
+        
+        let viewModelInitiationIntent = KevinAccountLinkingIntent.Initialize(configuration: configuration)
+        
+        let url = URL(string: "\(redirectURLMock)/?requestId=REQUEST_ID&status=success&code=\(authStateMock)")
+        let linkingCompletionIntent = KevinAccountLinkingIntent.HandleLinkingCompleted(
+            url: url,
+            error: nil,
+            configuration: configuration
+        )
+        
+        // 2. Act
+        expectation = expectation(description: "Account linking initiates")
+        KevinAccountLinkingSession.shared.initiateAccountLinking(configuration: sdkConfiguration)
+        waitForExpectations(timeout: 0.1)
+
+        expectation = expectation(description: "Account linking completed")
+        viewModel.offer(intent: viewModelInitiationIntent)
+        viewModel.offer(intent: linkingCompletionIntent)
+        waitForExpectations(timeout: 0.1)
+
+        // 3. Assert
+        let resultAuthorizationCode = try XCTUnwrap(authorizationCode)
+        let resultBank = try XCTUnwrap(bank)
+        
+        XCTAssertEqual(resultAuthorizationCode, authStateMock)
+        XCTAssertEqual(resultBank.id, selectedBankId)
+    }
+    
+    func testViewModelLinkingCompletionWithMissingCode() throws {
+        // 1. Assign
+        KevinAccountLinkingSession.shared.delegate = self
+        let sdkConfiguration = try KevinAccountLinkingSessionConfiguration.Builder(state: authStateMock)
+            .build()
+                
+        let selectedBankId = "INDUSTRA_LT"
+        let selectedCoutnry = KevinCountry.lithuania
+
+        let configuration = KevinAccountLinkingConfiguration(
+            state: authStateMock,
+            selectedBankId: selectedBankId,
+            selectedCountry: selectedCoutnry,
+            linkingType: .bank
+        )
+        
+        let viewModelInitiationIntent = KevinAccountLinkingIntent.Initialize(configuration: configuration)
+        
+        let url = URL(string: "\(redirectURLMock)/?requestId=REQUEST_ID&status=success")
+        let linkingCompletionIntent = KevinAccountLinkingIntent.HandleLinkingCompleted(
+            url: url,
+            error: nil,
+            configuration: configuration
+        )
+        
+        // 2. Act
+        expectation = expectation(description: "Account linking initiates")
+        KevinAccountLinkingSession.shared.initiateAccountLinking(configuration: sdkConfiguration)
+        waitForExpectations(timeout: 0.1)
+
+        expectation = expectation(description: "Account linking completed")
+        viewModel.offer(intent: viewModelInitiationIntent)
+        viewModel.offer(intent: linkingCompletionIntent)
+        waitForExpectations(timeout: 0.1)
+
+        // 3. Assert
+        let resultError = try XCTUnwrap(error) as? KevinError
+        
+        XCTAssertEqual(resultError, KevinErrors.accountAuthCodeMissing)
+    }
+    
+    func testViewModelLinkingCompletionWithMissingStatus() throws {
+        // 1. Assign
+        KevinAccountLinkingSession.shared.delegate = self
+        let sdkConfiguration = try KevinAccountLinkingSessionConfiguration.Builder(state: authStateMock)
+            .build()
+                
+        let selectedBankId = "INDUSTRA_LT"
+        let selectedCoutnry = KevinCountry.lithuania
+
+        let configuration = KevinAccountLinkingConfiguration(
+            state: authStateMock,
+            selectedBankId: selectedBankId,
+            selectedCountry: selectedCoutnry,
+            linkingType: .bank
+        )
+        
+        let viewModelInitiationIntent = KevinAccountLinkingIntent.Initialize(configuration: configuration)
+        
+        let url = URL(string: "\(redirectURLMock)/?requestId=REQUEST_ID&code=\(authStateMock)")
+        let linkingCompletionIntent = KevinAccountLinkingIntent.HandleLinkingCompleted(
+            url: url,
+            error: nil,
+            configuration: configuration
+        )
+        
+        // 2. Act
+        expectation = expectation(description: "Account linking initiates")
+        KevinAccountLinkingSession.shared.initiateAccountLinking(configuration: sdkConfiguration)
+        waitForExpectations(timeout: 0.1)
+
+        expectation = expectation(description: "Account linking completed")
+        viewModel.offer(intent: viewModelInitiationIntent)
+        viewModel.offer(intent: linkingCompletionIntent)
+        waitForExpectations(timeout: 0.1)
+
+        // 3. Assert
+        let resultError = try XCTUnwrap(error) as? KevinError
+        
+        XCTAssertEqual(resultError, KevinErrors.unknownLinkingStatus)
+    }
+    
+    func testViewModelLinkingCompletionWithFailedStatus() throws {
+        // 1. Assign
+        KevinAccountLinkingSession.shared.delegate = self
+        let sdkConfiguration = try KevinAccountLinkingSessionConfiguration.Builder(state: authStateMock)
+            .build()
+                
+        let selectedBankId = "INDUSTRA_LT"
+        let selectedCoutnry = KevinCountry.lithuania
+
+        let configuration = KevinAccountLinkingConfiguration(
+            state: authStateMock,
+            selectedBankId: selectedBankId,
+            selectedCountry: selectedCoutnry,
+            linkingType: .bank
+        )
+        
+        let viewModelInitiationIntent = KevinAccountLinkingIntent.Initialize(configuration: configuration)
+        
+        let url = URL(string: "\(redirectURLMock)/?requestId=REQUEST_ID&status=failed&code=\(authStateMock)")
+        let linkingCompletionIntent = KevinAccountLinkingIntent.HandleLinkingCompleted(
+            url: url,
+            error: nil,
+            configuration: configuration
+        )
+        
+        // 2. Act
+        expectation = expectation(description: "Account linking initiates")
+        KevinAccountLinkingSession.shared.initiateAccountLinking(configuration: sdkConfiguration)
+        waitForExpectations(timeout: 0.1)
+
+        expectation = expectation(description: "Account linking completed")
+        viewModel.offer(intent: viewModelInitiationIntent)
+        viewModel.offer(intent: linkingCompletionIntent)
+        waitForExpectations(timeout: 0.1)
+
+        // 3. Assert
+        let resultError = try XCTUnwrap(error) as? KevinError
+        
+        XCTAssertEqual(resultError, KevinErrors.linkingCanceled)
+    }
+    
+    func testViewModelLinkingCompletionWithError() throws {
+        // 1. Assign
+        KevinAccountLinkingSession.shared.delegate = self
+        let sdkConfiguration = try KevinAccountLinkingSessionConfiguration.Builder(state: authStateMock)
+            .build()
+                
+        let selectedBankId = "INDUSTRA_LT"
+        let selectedCoutnry = KevinCountry.lithuania
+
+        let configuration = KevinAccountLinkingConfiguration(
+            state: authStateMock,
+            selectedBankId: selectedBankId,
+            selectedCountry: selectedCoutnry,
+            linkingType: .bank
+        )
+        
+        let viewModelInitiationIntent = KevinAccountLinkingIntent.Initialize(configuration: configuration)
+        
+        let error = KevinError(description: "Custom test error")
+        let linkingCompletionIntent = KevinAccountLinkingIntent.HandleLinkingCompleted(
+            url: nil,
+            error: error,
+            configuration: configuration
+        )
+        
+        // 2. Act
+        expectation = expectation(description: "Account linking initiates")
+        KevinAccountLinkingSession.shared.initiateAccountLinking(configuration: sdkConfiguration)
+        waitForExpectations(timeout: 0.1)
+
+        expectation = expectation(description: "Account linking completed")
+        viewModel.offer(intent: viewModelInitiationIntent)
+        viewModel.offer(intent: linkingCompletionIntent)
+        waitForExpectations(timeout: 0.1)
+
+        // 3. Assert
+        let resultError = try XCTUnwrap(error)
+        
+        XCTAssertEqual(resultError, error)
+    }
+}
+
+extension KevinAccountLinkingViewModelTests: KevinAccountLinkingSessionDelegate {
+    
+    func onKevinAccountLinkingStarted(controller: UINavigationController) {
+        self.controller = controller
+        expectation?.fulfill()
+        expectation = nil
+    }
+    
+    func onKevinAccountLinkingCanceled(error: Error?) {
+        self.error = error
+        expectation?.fulfill()
+        expectation = nil
+    }
+    
+    func onKevinAccountLinkingSucceeded(authorizationCode: String, bank: ApiBank?, linkingType: KevinAccountLinkingType) {
+        self.authorizationCode = authorizationCode
+        self.bank = bank
+        expectation?.fulfill()
+        expectation = nil
+    }
+}
+
+private let banksResponse = """
+{
+  "data": [
+    {
+      "id": "INDUSTRA_LT",
+      "name": "Industra",
+      "officialName": "AS Industra Bank Lietuvos filialas",
+      "countryCode": "LT",
+      "isSandbox": false,
+      "imageUri": "https://cdn.kevin.eu/banks/images/INDUSTRA_LT.png",
+      "bic": "MULTLT2X",
+      "isBeta": false,
+      "isAccountLinkingSupported": true
+    }
+  ]
+}
+"""

--- a/Tests/KevinTests/ViewModels/KevinAccountLinkingViewModelTests.swift
+++ b/Tests/KevinTests/ViewModels/KevinAccountLinkingViewModelTests.swift
@@ -43,7 +43,8 @@ final class KevinAccountLinkingViewModelTests: XCTestCase {
             callbackUrl: URL(string: redirectURLMock)!
         ).build()
         KevinAccountsPlugin.shared.configure(configurationAccounts)
-        
+        KevinAccountLinkingSession.shared.delegate = self
+
         // MARK: Set up view model
         viewModel = KevinAccountLinkingViewModel()
         viewModel.onStateChanged = { [weak self] state in
@@ -81,7 +82,6 @@ final class KevinAccountLinkingViewModelTests: XCTestCase {
     
     func testViewModelLinkingCompletion() throws {
         // 1. Assign
-        KevinAccountLinkingSession.shared.delegate = self
         let sdkConfiguration = try KevinAccountLinkingSessionConfiguration.Builder(state: authStateMock)
             .build()
                 
@@ -124,7 +124,6 @@ final class KevinAccountLinkingViewModelTests: XCTestCase {
     
     func testViewModelLinkingCompletionWithMissingCode() throws {
         // 1. Assign
-        KevinAccountLinkingSession.shared.delegate = self
         let sdkConfiguration = try KevinAccountLinkingSessionConfiguration.Builder(state: authStateMock)
             .build()
                 
@@ -165,7 +164,6 @@ final class KevinAccountLinkingViewModelTests: XCTestCase {
     
     func testViewModelLinkingCompletionWithMissingStatus() throws {
         // 1. Assign
-        KevinAccountLinkingSession.shared.delegate = self
         let sdkConfiguration = try KevinAccountLinkingSessionConfiguration.Builder(state: authStateMock)
             .build()
                 
@@ -206,7 +204,6 @@ final class KevinAccountLinkingViewModelTests: XCTestCase {
     
     func testViewModelLinkingCompletionWithFailedStatus() throws {
         // 1. Assign
-        KevinAccountLinkingSession.shared.delegate = self
         let sdkConfiguration = try KevinAccountLinkingSessionConfiguration.Builder(state: authStateMock)
             .build()
                 
@@ -247,7 +244,6 @@ final class KevinAccountLinkingViewModelTests: XCTestCase {
     
     func testViewModelLinkingCompletionWithError() throws {
         // 1. Assign
-        KevinAccountLinkingSession.shared.delegate = self
         let sdkConfiguration = try KevinAccountLinkingSessionConfiguration.Builder(state: authStateMock)
             .build()
                 

--- a/Tests/KevinTests/ViewModels/KevinBankSelectionViewModelTests.swift
+++ b/Tests/KevinTests/ViewModels/KevinBankSelectionViewModelTests.swift
@@ -1,0 +1,193 @@
+//
+//  KevinBankSelectionViewModelTests.swift
+//  kevin.iOS
+//
+//  Created by Daniel Klinge on 11/09/2023.
+//  Copyright © 2023 kevin.. All rights reserved.
+//
+
+import XCTest
+
+@testable import Kevin
+
+final class KevinBankSelectionViewModelTests: XCTestCase {
+    
+    let authStateMock = "authStateMock"
+    
+    var viewModel: KevinBankSelectionViewModel!
+    var state: KevinBankSelectionState?
+    var expectation: XCTestExpectation?
+    
+    override func setUp() {
+        super.setUp()
+        
+        KevinApiClient.shared.urlSession = mockURLSession
+        
+        MockURLProtocol.add(handler: MockRequestHandler(
+            url: URL.banks(with: authStateMock).absoluteString + "?countryCode=lt",
+            jsonResponse: banksResponse,
+            customHandler: {
+                // NOTE: Waiting 0.5 sec for API call to process by view model
+                DispatchQueue.main.asyncAfter(deadline: .now() + 0.5, execute: {
+                    self.expectation?.fulfill()
+                    self.expectation = nil
+                })
+            }
+        ))
+        
+        viewModel = KevinBankSelectionViewModel()
+        viewModel.onStateChanged = { [weak self] state in
+            self?.state = state
+        }
+    }
+    
+    override func tearDown() {
+        super.tearDown()
+        MockURLProtocol.clearHandlers()
+    }
+    
+    func testViewModelInitiation() {
+        // 1. Assign
+        let selectedBankId = "INDUSTRA_LT"
+        let selectedCoutnry = KevinCountry.lithuania
+        let isCountrySelectionDisabled = true
+        
+        let configuration = KevinBankSelectionConfiguration(
+            selectedCountry: selectedCoutnry,
+            isCountrySelectionDisabled: isCountrySelectionDisabled,
+            countryFilter: [],
+            selectedBankId: selectedBankId,
+            authState: authStateMock,
+            exitSlug: "",
+            bankFilter: [],
+            excludeBanksWithoutAccountLinkingSupport: true,
+            confirmInteractiveDismiss:.never
+        )
+        let intent = KevinBankSelectionIntent.initialize(configuration: configuration)
+        
+        expectation = expectation(description: "Banks are loaded")
+        
+        // 2. Act
+        viewModel.offer(intent: intent)
+        
+        waitForExpectations(timeout: 1)
+        
+        // 3. Assert
+        XCTAssertEqual(state?.isLoading, false)
+        XCTAssertEqual(state?.selectedBankId, selectedBankId)
+        XCTAssertEqual(state?.selectedCountry, selectedCoutnry.rawValue)
+        XCTAssertEqual(state?.isCountrySelectionDisabled, true)
+        XCTAssertEqual(state?.bankItems.count, 2)
+    }
+    
+    func testViewModelInitiationWithBankFilter() {
+        // 1. Assign
+        let selectedBankId = "INDUSTRA_LT"
+        let bankFilter = [
+            "INDUSTRA_LT"
+        ]
+        let selectedCoutnry = KevinCountry.lithuania
+        let isCountrySelectionDisabled = true
+        
+        let configuration = KevinBankSelectionConfiguration(
+            selectedCountry: selectedCoutnry,
+            isCountrySelectionDisabled: isCountrySelectionDisabled,
+            countryFilter: [],
+            selectedBankId: selectedBankId,
+            authState: authStateMock,
+            exitSlug: "",
+            bankFilter: bankFilter,
+            excludeBanksWithoutAccountLinkingSupport: true,
+            confirmInteractiveDismiss:.never
+        )
+        let intent = KevinBankSelectionIntent.initialize(configuration: configuration)
+        
+        expectation = expectation(description: "Banks are loaded")
+        
+        // 2. Act
+        viewModel.offer(intent: intent)
+        
+        waitForExpectations(timeout: 1)
+        
+        // 3. Assert
+        XCTAssertEqual(state?.isLoading, false)
+        XCTAssertEqual(state?.selectedBankId, selectedBankId)
+        XCTAssertEqual(state?.selectedCountry, selectedCoutnry.rawValue)
+        XCTAssertEqual(state?.isCountrySelectionDisabled, true)
+        XCTAssertEqual(state?.bankItems.count, 1)
+    }
+    
+    func testViewModelInitiationWithUnsuportedBanks() {
+        // 1. Assign
+        let selectedBankId = "INDUSTRA_LT"
+        let selectedCoutnry = KevinCountry.lithuania
+        let isCountrySelectionDisabled = false
+        
+        let configuration = KevinBankSelectionConfiguration(
+            selectedCountry: selectedCoutnry,
+            isCountrySelectionDisabled: isCountrySelectionDisabled,
+            countryFilter: [],
+            selectedBankId: selectedBankId,
+            authState: authStateMock,
+            exitSlug: "",
+            bankFilter: [],
+            excludeBanksWithoutAccountLinkingSupport: false,
+            confirmInteractiveDismiss:.never
+        )
+        let intent = KevinBankSelectionIntent.initialize(configuration: configuration)
+        
+        expectation = expectation(description: "Banks are loaded")
+        
+        // 2. Act
+        viewModel.offer(intent: intent)
+        
+        waitForExpectations(timeout: 1)
+        
+        // 3. Assert
+        XCTAssertEqual(state?.isLoading, false)
+        XCTAssertEqual(state?.selectedBankId, selectedBankId)
+        XCTAssertEqual(state?.selectedCountry, selectedCoutnry.rawValue)
+        XCTAssertEqual(state?.isCountrySelectionDisabled, false)
+        XCTAssertEqual(state?.bankItems.count, 3)
+    }
+}
+
+private let banksResponse = """
+{
+  "data": [
+    {
+      "id": "INDUSTRA_LT",
+      "name": "Industra",
+      "officialName": "AS Industra Bank Lietuvos filialas",
+      "countryCode": "LT",
+      "isSandbox": false,
+      "imageUri": "https://cdn.kevin.eu/banks/images/INDUSTRA_LT.png",
+      "bic": "MULTLT2X",
+      "isBeta": false,
+      "isAccountLinkingSupported": true
+    },
+    {
+      "id": "REVOLUT_LT",
+      "name": "Revolut",
+      "officialName": "Revolut",
+      "countryCode": "LT",
+      "isSandbox": false,
+      "imageUri": "https://cdn.kevin.eu/banks/images/REVOLUT_LT.png",
+      "bic": "REVO",
+      "isBeta": false,
+      "isAccountLinkingSupported": true
+    },
+    {
+      "id": "UNSUPORTED_BANK",
+      "name": "Unsuported bank",
+      "officialName": "Unsuported bank",
+      "countryCode": "LT",
+      "isSandbox": false,
+      "imageUri": "",
+      "bic": "UNSUPORTED",
+      "isBeta": false,
+      "isAccountLinkingSupported": false
+    }
+  ]
+}
+"""

--- a/Tests/KevinTests/ViewModels/KevinBankSelectionViewModelTests.swift
+++ b/Tests/KevinTests/ViewModels/KevinBankSelectionViewModelTests.swift
@@ -28,7 +28,7 @@ final class KevinBankSelectionViewModelTests: XCTestCase {
             jsonResponse: banksResponse,
             customHandler: {
                 // NOTE: Waiting 0.5 sec for API call to process by view model
-                DispatchQueue.main.asyncAfter(deadline: .now() + 0.5, execute: {
+                DispatchQueue.main.asyncAfter(deadline: .now() + 0.2, execute: {
                     self.expectation?.fulfill()
                     self.expectation = nil
                 })
@@ -70,7 +70,7 @@ final class KevinBankSelectionViewModelTests: XCTestCase {
         // 2. Act
         viewModel.offer(intent: intent)
         
-        waitForExpectations(timeout: 1)
+        waitForExpectations(timeout: 0.5)
         
         // 3. Assert
         XCTAssertEqual(state?.isLoading, false)
@@ -107,7 +107,7 @@ final class KevinBankSelectionViewModelTests: XCTestCase {
         // 2. Act
         viewModel.offer(intent: intent)
         
-        waitForExpectations(timeout: 1)
+        waitForExpectations(timeout: 0.5)
         
         // 3. Assert
         XCTAssertEqual(state?.isLoading, false)
@@ -141,7 +141,7 @@ final class KevinBankSelectionViewModelTests: XCTestCase {
         // 2. Act
         viewModel.offer(intent: intent)
         
-        waitForExpectations(timeout: 1)
+        waitForExpectations(timeout: 0.5)
         
         // 3. Assert
         XCTAssertEqual(state?.isLoading, false)

--- a/Tests/KevinTests/ViewModels/KevinCountrySelectionViewModelTests.swift
+++ b/Tests/KevinTests/ViewModels/KevinCountrySelectionViewModelTests.swift
@@ -28,7 +28,7 @@ final class KevinCountrySelectionViewModelTests: XCTestCase {
             jsonResponse: countriesResponse,
             customHandler: {
                 // NOTE: Waiting 0.5 sec for API call to process by view model
-                DispatchQueue.main.asyncAfter(deadline: .now() + 0.5, execute: {
+                DispatchQueue.main.asyncAfter(deadline: .now() + 0.2, execute: {
                     self.expectation?.fulfill()
                     self.expectation = nil
                 })
@@ -62,7 +62,7 @@ final class KevinCountrySelectionViewModelTests: XCTestCase {
         // 2. Act
         viewModel.offer(intent: intent)
         
-        waitForExpectations(timeout: 1)
+        waitForExpectations(timeout: 0.5)
 
         // 3. Assert
         XCTAssertEqual(state?.isLoading, false)
@@ -90,7 +90,7 @@ final class KevinCountrySelectionViewModelTests: XCTestCase {
         // 2. Act
         viewModel.offer(intent: intent)
         
-        waitForExpectations(timeout: 1)
+        waitForExpectations(timeout: 0.5)
 
         // 3. Assert
         XCTAssertEqual(state?.isLoading, false)

--- a/Tests/KevinTests/ViewModels/KevinCountrySelectionViewModelTests.swift
+++ b/Tests/KevinTests/ViewModels/KevinCountrySelectionViewModelTests.swift
@@ -1,0 +1,110 @@
+//
+//  KevinCountrySelectionViewModelTests.swift
+//  kevin.iOS
+//
+//  Created by Daniel Klinge on 11/09/2023.
+//  Copyright © 2023 kevin.. All rights reserved.
+//
+
+import XCTest
+
+@testable import Kevin
+
+final class KevinCountrySelectionViewModelTests: XCTestCase {
+    
+    let authStateMock = "authStateMock"
+    
+    var viewModel: KevinCountrySelectionViewModel!
+    var state: KevinCountrySelectionState?
+    var expectation: XCTestExpectation?
+
+    override func setUp() {
+        super.setUp()
+        
+        KevinApiClient.shared.urlSession = mockURLSession
+        
+        MockURLProtocol.add(handler: MockRequestHandler(
+            url: URL.countries(with: authStateMock).absoluteString,
+            jsonResponse: countriesResponse,
+            customHandler: {
+                // NOTE: Waiting 0.5 sec for API call to process by view model
+                DispatchQueue.main.asyncAfter(deadline: .now() + 0.5, execute: {
+                    self.expectation?.fulfill()
+                    self.expectation = nil
+                })
+            }
+        ))
+
+        viewModel = KevinCountrySelectionViewModel()
+        viewModel.onStateChanged = { [weak self] state in
+            self?.state = state
+        }
+    }
+    
+    override func tearDown() {
+        super.tearDown()
+        MockURLProtocol.clearHandlers()
+    }
+    
+    func testViewModelInitiation() {
+        // 1. Assign
+        let selectedCoutnry = KevinCountry.lithuania
+        
+        let configuration = KevinCountrySelectionConfiguration(
+            selectedCountry: selectedCoutnry.rawValue,
+            countryFilter: [],
+            authState: authStateMock
+        )
+        let intent = KevinCountrySelectionIntent.Initialize(configuration: configuration)
+        
+        expectation = expectation(description: "Countries are loaded")
+        
+        // 2. Act
+        viewModel.offer(intent: intent)
+        
+        waitForExpectations(timeout: 1)
+
+        // 3. Assert
+        XCTAssertEqual(state?.isLoading, false)
+        XCTAssertEqual(state?.selectedCountry, selectedCoutnry.rawValue)
+        XCTAssertEqual(state?.supportedCountries.count, 3)
+    }
+    
+    func testViewModelInitiationWithCountryFilter() {
+        // 1. Assign
+        let selectedCoutnry = KevinCountry.lithuania
+        let countryFilter = [
+            KevinCountry.lithuania,
+            KevinCountry.latvia
+        ]
+        
+        let configuration = KevinCountrySelectionConfiguration(
+            selectedCountry: selectedCoutnry.rawValue,
+            countryFilter: countryFilter,
+            authState: authStateMock
+        )
+        let intent = KevinCountrySelectionIntent.Initialize(configuration: configuration)
+        
+        expectation = expectation(description: "Countries are loaded")
+
+        // 2. Act
+        viewModel.offer(intent: intent)
+        
+        waitForExpectations(timeout: 1)
+
+        // 3. Assert
+        XCTAssertEqual(state?.isLoading, false)
+        XCTAssertEqual(state?.selectedCountry, selectedCoutnry.rawValue)
+        XCTAssertEqual(state?.supportedCountries.count, 2)
+    }
+}
+
+private let countriesResponse = """
+{
+  "data": [
+    "lv",
+    "lt",
+    "ee"
+  ]
+}
+"""

--- a/Tests/KevinTests/ViewModels/KevinPaymentConfirmationViewModelTests.swift
+++ b/Tests/KevinTests/ViewModels/KevinPaymentConfirmationViewModelTests.swift
@@ -1,0 +1,240 @@
+//
+//  KevinPaymentConfirmationViewModelTests.swift
+//  kevin.iOS
+//
+//  Created by Daniel Klinge on 11/09/2023.
+//  Copyright © 2023 kevin.. All rights reserved.
+//
+
+import XCTest
+
+@testable import Kevin
+
+final class KevinPaymentConfirmationViewModelTests: XCTestCase {
+    
+    let paymentIdMock = "paymentIdMock"
+    let redirectURLMock = "https://redirectURLMock.test/authorization.html"
+
+    var viewModel: KevinPaymentConfirmationViewModel!
+    var state: KevinPaymentConfirmationState?
+
+    var expectation: XCTestExpectation?
+    var controller: UINavigationController?
+    var error: Error?
+    var paymentId: String?
+    var status: KevinPaymentStatus?
+
+    override func setUp() {
+        super.setUp()
+        
+        // MARK: Set up networking mock
+        KevinApiClient.shared.urlSession = mockURLSession
+        MockURLProtocol.add(handler: MockRequestHandler(
+            url: URL.banks(with: paymentIdMock).absoluteString,
+            jsonResponse: banksResponse
+        ))
+        
+        // MARK: Set up SDK
+        let configurationPayments = KevinInAppPaymentsConfiguration.Builder(
+            callbackUrl: URL(string: redirectURLMock)!
+        ).build()
+        KevinInAppPaymentsPlugin.shared.configure(configurationPayments)
+        KevinPaymentSession.shared.delegate = self
+
+        // MARK: Set up view model
+        viewModel = KevinPaymentConfirmationViewModel()
+        viewModel.onStateChanged = { [weak self] state in
+            self?.state = state
+        }
+    }
+
+    override func tearDown() {
+        super.tearDown()
+        MockURLProtocol.clearHandlers()
+    }
+    
+    func testViewModelInitiation() {
+        // 1. Assign
+        let selectedBankId = "INDUSTRA_LT"
+
+        let configuration = KevinPaymentConfirmationConfiguration(
+            paymentId: paymentIdMock,
+            paymentType: .bank,
+            selectedBank: selectedBankId,
+            skipAuthentication: false,
+            confirmInteractiveDismiss: .never
+        )
+        let intent = KevinPaymentConfirmationIntent.Initialize(configuration: configuration)
+
+        let expectedBaseUrl = String(
+            format: KevinApiPaths.bankPaymentUrl,
+            configuration.paymentId,
+            configuration.selectedBank!,
+            Kevin.shared.locale.identifier.lowercased()
+        )
+
+        // 2. Act
+        viewModel.offer(intent: intent)
+        
+        // 3. Assert
+        XCTAssertEqual(state?.url.absoluteString.contains(expectedBaseUrl), true)
+    }
+
+    func testViewModelInitiationWithSkipAuthentication() {
+        // 1. Assign
+        let selectedBankId = "INDUSTRA_LT"
+
+        let configuration = KevinPaymentConfirmationConfiguration(
+            paymentId: paymentIdMock,
+            paymentType: .bank,
+            selectedBank: selectedBankId,
+            skipAuthentication: true,
+            confirmInteractiveDismiss: .never
+        )
+        let intent = KevinPaymentConfirmationIntent.Initialize(configuration: configuration)
+        
+        let expectedBaseUrl = String(
+            format: KevinApiPaths.bankPaymentAuthenticatedUrl,
+            configuration.paymentId,
+            Kevin.shared.locale.identifier.lowercased()
+        )
+
+        // 2. Act
+        viewModel.offer(intent: intent)
+        
+        // 3. Assert
+        XCTAssertEqual(state?.url.absoluteString.contains(expectedBaseUrl), true)
+    }
+
+    func testViewModelPaymentCompletion() throws {
+        // 1. Assign
+        let url = URL(string: "\(redirectURLMock)/?paymentId=\(paymentIdMock)&status=ACSC&statusGroup=completed")
+        let paymentCompletionIntent = KevinPaymentConfirmationIntent.HandlePaymentCompleted(
+            url: url,
+            error: nil
+        )
+        
+        // 2. Act
+        expectation = expectation(description: "Payment completed")
+        viewModel.offer(intent: paymentCompletionIntent)
+        waitForExpectations(timeout: 0.1)
+
+        // 3. Assert
+        let resultPaymentId = try XCTUnwrap(paymentId)
+        let resultStatus = try XCTUnwrap(status)
+        
+        XCTAssertEqual(resultPaymentId, paymentIdMock)
+        XCTAssertEqual(resultStatus, .completed)
+    }
+
+    func testViewModelPaymentCompletionWithMissingStatusGroup() throws {
+        // 1. Assign
+        let url = URL(string: "\(redirectURLMock)/?paymentId=\(paymentIdMock)&status=ACSC")
+        let paymentCompletionIntent = KevinPaymentConfirmationIntent.HandlePaymentCompleted(
+            url: url,
+            error: nil
+        )
+        
+        // 2. Act
+        expectation = expectation(description: "Payment completed")
+        viewModel.offer(intent: paymentCompletionIntent)
+        waitForExpectations(timeout: 0.1)
+
+        // 3. Assert
+        let resultError = try XCTUnwrap(error) as? KevinError
+        
+        XCTAssertEqual(resultError, KevinErrors.unknownPaymentStatus)
+    }
+    
+    func testViewModelPaymentCompletionWithUnknownStatusGroup() throws {
+        // 1. Assign
+        let url = URL(string: "\(redirectURLMock)/?paymentId=\(paymentIdMock)&status=ACSC&statusGroup=unknown")
+        let paymentCompletionIntent = KevinPaymentConfirmationIntent.HandlePaymentCompleted(
+            url: url,
+            error: nil
+        )
+        
+        // 2. Act
+        expectation = expectation(description: "Payment completed")
+        viewModel.offer(intent: paymentCompletionIntent)
+        waitForExpectations(timeout: 0.1)
+
+        // 3. Assert
+        let resultError = try XCTUnwrap(error) as? KevinError
+        
+        XCTAssertEqual(resultError, KevinErrors.unknownPaymentStatus)
+    }
+    
+    func testViewModelPaymentCompletionWithUnexpectedStatusGroup() throws {
+        // 1. Assign
+        let url = URL(string: "\(redirectURLMock)/?paymentId=\(paymentIdMock)&status=ACSC&statusGroup=unexpected")
+        let paymentCompletionIntent = KevinPaymentConfirmationIntent.HandlePaymentCompleted(
+            url: url,
+            error: nil
+        )
+        
+        // 2. Act
+        expectation = expectation(description: "Payment completed")
+        viewModel.offer(intent: paymentCompletionIntent)
+        waitForExpectations(timeout: 0.1)
+
+        // 3. Assert
+        let resultError = try XCTUnwrap(error) as? KevinError
+        
+        XCTAssertEqual(resultError, KevinErrors.unknownPaymentStatus)
+    }
+    
+    func testViewModelPaymentCompletionWithError() throws {
+        // 1. Assign
+        let error = KevinError(description: "Custom test error")
+        let paymentCompletionIntent = KevinPaymentConfirmationIntent.HandlePaymentCompleted(
+            url: nil,
+            error: error
+        )
+        
+        // 2. Act
+        expectation = expectation(description: "Payment completed")
+        viewModel.offer(intent: paymentCompletionIntent)
+        waitForExpectations(timeout: 0.1)
+
+        // 3. Assert
+        let resultError = try XCTUnwrap(error)
+        
+        XCTAssertEqual(resultError, error)
+    }
+}
+
+extension KevinPaymentConfirmationViewModelTests: KevinPaymentSessionDelegate {
+    func onKevinPaymentInitiationStarted(controller: UINavigationController) { }
+    
+    func onKevinPaymentCanceled(error: Error?) {
+        self.error = error
+        expectation?.fulfill()
+        expectation = nil
+    }
+    
+    func onKevinPaymentSucceeded(paymentId: String, status: KevinPaymentStatus) {
+        self.paymentId = paymentId
+        self.status = status
+        expectation?.fulfill()
+        expectation = nil
+    }
+}
+
+private let banksResponse = """
+{
+  "data": [
+    {
+      "id": "INDUSTRA_LT",
+      "name": "Industra",
+      "officialName": "AS Industra Bank Lietuvos filialas",
+      "countryCode": "LT",
+      "isSandbox": false,
+      "imageUri": "https://cdn.kevin.eu/banks/images/INDUSTRA_LT.png",
+      "bic": "MULTLT2X",
+      "isBeta": false,
+      "isAccountLinkingSupported": true
+    }
+  ]
+}
+"""


### PR DESCRIPTION
Added tests to:
- ViewModels
- Linking / Payment Session 
- Linking / Payment Configurations (those have some error thrown)